### PR TITLE
Messagebox

### DIFF
--- a/include/SH3/stdtype.hpp
+++ b/include/SH3/stdtype.hpp
@@ -30,6 +30,8 @@ Revision History:
 #include <cstring>
 #include <cstdarg>
 
+#include <SDL2/SDL_messagebox.h>
+
     // Cross platform ;)
 #ifdef _WIN32
     #define WIN32_LEAN_AND_MEAN
@@ -70,14 +72,8 @@ static inline void messagebox(const char* title, const char* str, ...)
     vsnprintf(buff, sizeof(buff), str, args);
     va_end(args);
 
-    // Cross platform ;)
-    #ifdef _WIN32
-        MessageBox(NULL, buff, title, MB_OK);
-    #elif __APPLE__ // No idea for this, Apple probably have it behine 602348483468034684056 layers of fucking bullshit, the arseholes.
-
-    #elif __linux__ // This no way in hell this will be standard, we should probably just have the console open!
-
-    #endif
+    // TODO: properly get window parent
+    SDL_ShowSimpleMessageBox(0, title, buff, nullptr);
 }
 
 

--- a/include/SH3/stdtype.hpp
+++ b/include/SH3/stdtype.hpp
@@ -67,7 +67,7 @@ static inline void messagebox(const char* title, const char* str, ...)
 
     // Get our variable args, like %x, %s etcetc
     va_start(args, str);
-    vsprintf(buff, str, args);
+    vsnprintf(buff, sizeof(buff), str, args);
     va_end(args);
 
     // Cross platform ;)


### PR DESCRIPTION
In another commit, the first parameter for `SDL_ShowSimpleMessageBox()` could also be passed in `messagebox()` to allow different types of dialogues to be used.

Perhaps `messagebox()` should be completely removed in favour of directly using `SDL_ShowSimpleMessageBox()`, which also allows the caller to select an appropriate buffer size if `sprintf` is required.