### PR TITLE
Use std::vector in favor of T* arrays

### DIFF
--- a/include/SH3/arc/sh3_arc_types.hpp
+++ b/include/SH3/arc/sh3_arc_types.hpp
@@ -60,6 +60,7 @@ Revision History:
 #include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 #include <zlib.h>
 
 #define ARCARC_MAGIC        0x20030417
@@ -115,11 +116,11 @@ typedef struct
 class sh3_arc_section
 {
 public:
-    sh3_arc_section_header_t    header;
-    sh3_arc_file_entry_t**      fileEntries;
+    sh3_arc_section_header_t          header;
+    std::vector<sh3_arc_file_entry_t> fileEntries;
 
     sh3_arc_section(){};
-    ~sh3_arc_section(){delete[] fileEntries;};
+    ~sh3_arc_section(){};
 
     std::string sectionName; // Name of this section
 
@@ -134,12 +135,12 @@ public:
 class sh3_arc
 {
 public:
-    sh3_arc_mft_header_t    s_fileHeader;   // First 16 bytes of the file. Contains the file signature
-    sh3_arc_data_header_t   s_infoHeader;   // Information about the MFT
-    sh3_arc_section*        c_pSections;    // List of all the sections in arc.arc
+    sh3_arc_mft_header_t         s_fileHeader;   // First 16 bytes of the file. Contains the file signature
+    sh3_arc_data_header_t        s_infoHeader;   // Information about the MFT
+    std::vector<sh3_arc_section> c_sections;    // List of all the sections in arc.arc
 
     sh3_arc(){Load();};
-    ~sh3_arc(){delete[] c_pSections;};
+    ~sh3_arc(){};
 
     // FUNCTION DECLARATIONS
     bool Load();

--- a/source/arc/sh3_arc_section.cpp
+++ b/source/arc/sh3_arc_section.cpp
@@ -51,18 +51,16 @@ bool sh3_arc_section::Load(sh3_arc_file& arcFile)
 
     // We have now loaded information about the section, so we can start
     // reading in all the files located in it (not in full, obviously...)
-    fileEntries = new sh3_arc_file_entry_t*[header.numFiles];
+    fileEntries.resize(header.numFiles);
 
-    for(unsigned int i = 0; i < header.numFiles; i++)
+    for(sh3_arc_file_entry_t& file : fileEntries)
     {
-        sh3_arc_file_entry_t* file = new sh3_arc_file_entry_t;
-        arcFile.ReadObject(file->header);
+        arcFile.ReadObject(file.header);
 
-        arcFile.ReadString(file->fname, file->header.fileSize - sizeof(file->header));
+        arcFile.ReadString(file.fname, file.header.fileSize - sizeof(file.header));
         //Log(LOG_INFO, "Read file: %s", file->fname.c_str());
 
-        fileEntries[i] = file;
-        fileList[file->fname] = file->header.arcIndex; // Map the file name to its subarc index
+        fileList[file.fname] = file.header.arcIndex; // Map the file name to its subarc index
         //Log(LOG_INFO, "Added file to file list!");
     }
 


### PR DESCRIPTION
This provides "automatic" memory management.

This commit also removes one pointer indirection of `sh3_arc_section::fileEntries`, which seemed unnecessary.