### PR TITLE
Use proper std:: prefixes

### DIFF
--- a/include/SH3/arc/file.hpp
+++ b/include/SH3/arc/file.hpp
@@ -23,6 +23,7 @@ Revision History:
 
 #include <zlib.h>
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -50,13 +51,13 @@ public:
 
     bool is_open() const {return static_cast<bool>(gzHandle);}
 
-    read_result ReadData(void* destination, size_t len);
+    read_result ReadData(void* destination, std::size_t len);
     template<typename T, typename = std::enable_if<std::is_standard_layout<T>::value>>
-    read_result ReadObject(T& destination, size_t len = sizeof(T))
+    read_result ReadObject(T& destination, std::size_t len = sizeof(T))
     {
         return ReadData(&destination, len);
     }
-    read_result ReadString(std::string& destination, size_t len);
+    read_result ReadString(std::string& destination, std::size_t len);
 
 private:
     std::unique_ptr<gzFile_s, gz_file_closer> gzHandle;

--- a/include/SH3/arc/section.hpp
+++ b/include/SH3/arc/section.hpp
@@ -28,18 +28,18 @@ Revision History:
 
 typedef struct
 {
-    uint32_t magic;             // File magic number
-    uint32_t numFiles;          // Number of files located in this sub .arc
-    uint32_t dataPointer;       // Pointer to the beginning of the data section
-    uint32_t unused;            // Unused DWORD
+    std::uint32_t magic;             // File magic number
+    std::uint32_t numFiles;          // Number of files located in this sub .arc
+    std::uint32_t dataPointer;       // Pointer to the beginning of the data section
+    std::uint32_t unused;            // Unused DWORD
 } sh3_subarc_header_t;
 
 typedef struct
 {
-    uint32_t offset;            // Offset file resides at
-    uint32_t fileID;            // FileID????
-    uint32_t length;            // Length of this file (in bytes)
-    uint32_t length2;
+    std::uint32_t offset;            // Offset file resides at
+    std::uint32_t fileID;            // FileID????
+    std::uint32_t length;            // Length of this file (in bytes)
+    std::uint32_t length2;
 } sh3_subarc_file_t;
 
 

--- a/include/SH3/arc/types.hpp
+++ b/include/SH3/arc/types.hpp
@@ -74,34 +74,34 @@ struct sh3_arc_file;
 // Type check header (an unfortunate waste of space)
 typedef struct
 {
-    uint32_t file_marker;   // File marker for arc.arc, this is ALWAYS 0x20030417
-    uint32_t unused[3];     // 3 filler DWORDs
+    std::uint32_t file_marker;   // File marker for arc.arc, this is ALWAYS 0x20030417
+    std::uint32_t unused[3];     // 3 filler DWORDs
 } sh3_arc_mft_header_t;
 
 // Info about the MFT
 typedef struct
 {
-    uint16_t type;          // This is 1 (for arc.arc info )
-    uint16_t header_size;   // Size of this header
-    uint32_t sectionCount;  // How many sections there are in the mft (i.e how many .arc files in /data/)
-    uint32_t fileCount;     // Number of files in this section
+    std::uint16_t type;          // This is 1 (for arc.arc info )
+    std::uint16_t header_size;   // Size of this header
+    std::uint32_t sectionCount;  // How many sections there are in the mft (i.e how many .arc files in /data/)
+    std::uint32_t fileCount;     // Number of files in this section
 } sh3_arc_data_header_t;
 
 // Info about a section
 typedef struct
 {
-    uint16_t type;      // This is 2 (for an arc section header)
-    uint16_t hsize;     // Size of this header in bytes
-    uint32_t numFiles;  // Number of files in this section
+    std::uint16_t type;      // This is 2 (for an arc section header)
+    std::uint16_t hsize;     // Size of this header in bytes
+    std::uint32_t numFiles;  // Number of files in this section
 } sh3_arc_section_header_t;
 
 // Info about a file in a section
 typedef struct
 {
-    uint16_t type;          // This is 3 (for a file entry)
-    uint16_t fileSize;      // Size of this file entry(in bytes)
-    uint16_t arcIndex;      // Index of this file (in the .arc it is located in)
-    uint16_t sectionIndex;  // Index of the current section we are in.
+    std::uint16_t type;          // This is 3 (for a file entry)
+    std::uint16_t fileSize;      // Size of this file entry(in bytes)
+    std::uint16_t arcIndex;      // Index of this file (in the .arc it is located in)
+    std::uint16_t sectionIndex;  // Index of the current section we are in.
 } sh3_arc_file_header_t;
 
 // Actual file entry
@@ -125,7 +125,7 @@ public:
     std::string sectionName; // Name of this section
 
     // Should this be private?!?!
-    std::map<std::string, uint32_t> fileList; // Maps a file (and its associated virtual path) to it's section index
+    std::map<std::string, std::uint32_t> fileList; // Maps a file (and its associated virtual path) to it's section index
 
     // FUNCTION DECLARATIONS
     bool Load(sh3_arc_file& fHandle);
@@ -144,7 +144,7 @@ public:
 
     // FUNCTION DECLARATIONS
     bool Load();
-    int LoadFile(char* filename, uint8_t* buffer);
+    int LoadFile(char* filename, std::uint8_t* buffer);
 
 };
 

--- a/include/SH3/graphics/model.hpp
+++ b/include/SH3/graphics/model.hpp
@@ -26,13 +26,13 @@ Revision History:
 
 typedef struct
 {
-    uint32_t unused1;               // Unused DWORD
-    uint32_t modelID;               // Model Identifier (not sure how this was used yet)
-    uint32_t numTextures;           // Number of textures for this model (1 model can contain many textures, i.e, Heather and Memory of Alessa)
-    uint32_t textureDataoffset;     // Offset to the start of the (first??) texture.
-    uint32_t headerSize;            // Size of this header
-    uint32_t unused2;               // Unused DWORD
-    uint32_t unused[8];             // Jesus Christ, KONAMI.....
+    std::uint32_t unused1;               // Unused DWORD
+    std::uint32_t modelID;               // Model Identifier (not sure how this was used yet)
+    std::uint32_t numTextures;           // Number of textures for this model (1 model can contain many textures, i.e, Heather and Memory of Alessa)
+    std::uint32_t textureDataoffset;     // Offset to the start of the (first??) texture.
+    std::uint32_t headerSize;            // Size of this header
+    std::uint32_t unused2;               // Unused DWORD
+    std::uint32_t unused[8];             // Jesus Christ, KONAMI.....
 } sh3_model_header_t;
 
 

--- a/include/SH3/graphics/texture.hpp
+++ b/include/SH3/graphics/texture.hpp
@@ -29,26 +29,26 @@ Revision History:
 
 typedef struct
 {
-    uint32_t    batchHeaderMarker;          // This should be 0xFFFFFFFF to mark a header chunk
-    uint32_t    unused1;                    // There are a lot of unused DWORDs, I assume to align everything nicely
-    uint32_t    batchHeaderSize;            // Size of the first part of the whole header
-    uint32_t    batchSize;                  // = res * res * (bpp/8) * #tex + 128 * #tex
-    uint32_t    unused2;
-    uint32_t    numBatchedTextures;         // Number of textures in this texture file
-    uint32_t    unused3[2];
-    uint32_t    texHeaderSegMarker;         // Secondary texture marker. This signifies the start of the texture information header
-    uint32_t    unused4;
-    uint16_t    texWidth;                   // The width of this texture
-    uint16_t    texHeight;                  // The height of this texture;
-    uint8_t     bpp;                        // Number of bits per pixel of this texture. NOTE: 8bpp is believed to be paletted!
-    uint8_t     dataOffset;                 // #bytes from texHeaderSize+16 to 128 (0 filled)
-    uint16_t    unused5;
-    uint32_t    texSize;                    // The size of this texture in bytes (w * h * [bpp/8])
-    uint32_t    texHeaderSize;              // = texSize + texHeaderSize + 16 + endFilleSize
-    uint32_t    unused6;
-    uint32_t    unknown1;                   // Completely unknown, probably unimportant for now
-    uint32_t    unknown2;                   // Usually 1!
-    uint32_t    unused7[15];
+    std::uint32_t batchHeaderMarker;          // This should be 0xFFFFFFFF to mark a header chunk
+    std::uint32_t unused1;                    // There are a lot of unused DWORDs, I assume to align everything nicely
+    std::uint32_t batchHeaderSize;            // Size of the first part of the whole header
+    std::uint32_t batchSize;                  // = res * res * (bpp/8) * #tex + 128 * #tex
+    std::uint32_t unused2;
+    std::uint32_t numBatchedTextures;         // Number of textures in this texture file
+    std::uint32_t unused3[2];
+    std::uint32_t texHeaderSegMarker;         // Secondary texture marker. This signifies the start of the texture information header
+    std::uint32_t unused4;
+    std::uint16_t texWidth;                   // The width of this texture
+    std::uint16_t texHeight;                  // The height of this texture;
+    std::uint8_t  bpp;                        // Number of bits per pixel of this texture. NOTE: 8bpp is believed to be paletted!
+    std::uint8_t  dataOffset;                 // #bytes from texHeaderSize+16 to 128 (0 filled)
+    std::uint16_t unused5;
+    std::uint32_t texSize;                    // The size of this texture in bytes (w * h * [bpp/8])
+    std::uint32_t texHeaderSize;              // = texSize + texHeaderSize + 16 + endFilleSize
+    std::uint32_t unused6;
+    std::uint32_t unknown1;                   // Completely unknown, probably unimportant for now
+    std::uint32_t unknown2;                   // Usually 1!
+    std::uint32_t unused7[15];
 } sh3_texture_header;
 
 

--- a/source/SH3/arc/file.cpp
+++ b/source/SH3/arc/file.cpp
@@ -21,6 +21,7 @@ Revision History:
 #include "SH3/arc/file.hpp"
 
 #include <cassert>
+#include <cstddef>
 #include <iterator>
 #include <vector>
 
@@ -42,7 +43,7 @@ Return Type:
         sh3_arc_file::read_result
 
 --*/
-sh3_arc_file::read_result sh3_arc_file::ReadData(void* destination, size_t len)
+sh3_arc_file::read_result sh3_arc_file::ReadData(void* destination, std::size_t len)
 {
     assert(static_cast<int>(len) > 0); // overflow check
 
@@ -79,7 +80,7 @@ Return Type:
         sh3_arc_file::read_result
 
 --*/
-sh3_arc_file::read_result sh3_arc_file::ReadString(std::string& destination, size_t len)
+sh3_arc_file::read_result sh3_arc_file::ReadString(std::string& destination, std::size_t len)
 {
     assert(static_cast<int>(len) > 0); // overflow check
 

--- a/source/SH3/arc/types.cpp
+++ b/source/SH3/arc/types.cpp
@@ -31,6 +31,8 @@ Revision History:
 #include "SH3/arc/file.hpp"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <utility>
 
@@ -106,11 +108,11 @@ Return Type:
         int - File length or 0 if none existent
 
 --*/
-int sh3_arc::LoadFile(char* filename, uint8_t* buffer)
+int sh3_arc::LoadFile(char* filename, std::uint8_t* buffer)
 {
-    uint32_t         index;
-    uint8_t*         buff;
-    FILE*            sectionHandle;
+    std::uint32_t    index;
+    std::uint8_t*    buff;
+    std::FILE*       sectionHandle;
     sh3_arc_section* section = nullptr;
 
     // Find what section the file is in
@@ -134,7 +136,7 @@ int sh3_arc::LoadFile(char* filename, uint8_t* buffer)
         return ARC_FILE_NOT_FOUND;
     }
 
-    if((sectionHandle = fopen(section->sectionName.c_str(), "rb")) == nullptr)
+    if((sectionHandle = std::fopen(section->sectionName.c_str(), "rb")) == nullptr)
     {
         die("E00005: sh3_arc::LoadFile( ): Unable to open a handle to section, %s!", section->sectionName.c_str());
     }
@@ -145,26 +147,26 @@ int sh3_arc::LoadFile(char* filename, uint8_t* buffer)
     sh3_subarc_header_t header;
     sh3_subarc_file_t   fileEntry;
 
-    fread(&header, 1, sizeof(sh3_subarc_header_t), sectionHandle); // Read in the header
+    std::fread(&header, 1, sizeof(sh3_subarc_header_t), sectionHandle); // Read in the header
 
     if(header.magic != ARCSECTION_MAGIC) // Validate the magic number to make sure we're really reading a .arc file!
     {
         die("sh3_arc::LoadFile( ): Subarc [%s] magic is incorrect! (Perhaps the file is corrupt!?)", section->sectionName.c_str());
     }
 
-    fseek(sectionHandle, index * sizeof(sh3_subarc_file_t), SEEK_CUR); // Seek to the file entry
-    fread(&fileEntry, 1, sizeof(sh3_subarc_file_t), sectionHandle);
+    std::fseek(sectionHandle, index * sizeof(sh3_subarc_file_t), SEEK_CUR); // Seek to the file entry
+    std::fread(&fileEntry, 1, sizeof(sh3_subarc_file_t), sectionHandle);
 
-    buff = new uint8_t[fileEntry.length]; // Allocate new buffer
+    buff = new std::uint8_t[fileEntry.length]; // Allocate new buffer
 
-    fseek(sectionHandle, fileEntry.offset, SEEK_SET); // Seek to file Data
-    fread(buff, 1, fileEntry.length, sectionHandle);
+    std::fseek(sectionHandle, fileEntry.offset, SEEK_SET); // Seek to file Data
+    std::fread(buff, 1, fileEntry.length, sectionHandle);
 
-    memcpy(buffer, buff, fileEntry.length); // Copy to param buffer
+    std::memcpy(buffer, buff, fileEntry.length); // Copy to param buffer
 
     delete buff; // No memory leaks in THIS dojo!
 
-    fclose(sectionHandle);
+    std::fclose(sectionHandle);
 
     return fileEntry.length;
 }

--- a/source/SH3/system/config.cpp
+++ b/source/SH3/system/config.cpp
@@ -46,9 +46,9 @@ Return Type:
 --*/
 int sh3_config::Load()
 {
-    FILE*   cfgfile;
+    std::FILE* cfgfile;
 
-    if((cfgfile = fopen(CFGPATH, "r")) != NULL)
+    if((cfgfile = std::fopen(CFGPATH, "r")) != NULL)
     {
         int         nStrs;
         char        commandc[512];
@@ -56,9 +56,9 @@ int sh3_config::Load()
 
         std::vector<std::string> args;
 
-        while(!feof(cfgfile))
+        while(!std::feof(cfgfile))
         {
-            fgets(commandc, 512, cfgfile); // Get in one command of text
+            std::fgets(commandc, 512, cfgfile); // Get in one command of text
             command = commandc;
 
             // Now, split the command up and store its' value in our map (that we can use later!! :] )

--- a/source/SH3/system/glcontext.cpp
+++ b/source/SH3/system/glcontext.cpp
@@ -19,6 +19,7 @@ Revision History:
         22-12-2016: File Created                                        [jbuhagiar]
 --*/
 #include <cstdio>
+#include <cstdlib>
 
 #include "SH3/stdtype.hpp"
 #include "SH3/system/glcontext.hpp"
@@ -37,7 +38,7 @@ sh3_glcontext::sh3_glcontext(sh3_window& hwnd)
     if(glewInit() != GLEW_OK) // Initialise GLEW!
     {
         Log(LogLevel::Fatal, "sh3_glcontext::sh3_glcontext( ): GLEW Init failed!");
-        exit(-1);
+        std::exit(-1);
     }
 
     // Set the colour size for OpenGL!
@@ -147,9 +148,9 @@ void sh3_glcontext::PrintInfo() const
     Log(LogLevel::Info, "GL_VERSION:\t %s", GetVersion());
     Log(LogLevel::Info, "GL_RENDERER:\t %s", GetRenderer());
 
-    printf("GL_VENDOR:\t %s\n", GetVendor());
-    printf("GL_VERSION:\t %s\n", GetVersion());
-    printf("GL_RENDERER:\t %s\n", GetRenderer());
+    std::printf("GL_VENDOR:\t %s\n", GetVendor());
+    std::printf("GL_VERSION:\t %s\n", GetVersion());
+    std::printf("GL_RENDERER:\t %s\n", GetRenderer());
 }
 
 /*++

--- a/source/SH3/system/log.cpp
+++ b/source/SH3/system/log.cpp
@@ -27,23 +27,23 @@ Revision History:
 #include "SH3/stdtype.hpp"
 
 #include <cstdio>
-#include <cstring>
 #include <cstdarg>
+#include <SDL2/SDL_messagebox.h>
 
 #include <SDL2/SDL_messagebox.h>
 
 void Log(LogLevel logType, const char* str, ...)
 {
     static const char* filename = "log.txt";
-    static FILE*       logfile  = nullptr;
+    static std::FILE*  logfile  = nullptr;
 
-    va_list args;
+    std::va_list args;
 
     if(!logfile)
     {
-        if(!(logfile = fopen(filename, "w+")))
+        if(!(logfile = std::fopen(filename, "w+")))
         {
-            fprintf(stderr, "Unable to open a handle to %s", filename);
+            std::fprintf(stderr, "Unable to open a handle to %s", filename);
             // fallback to stderr then
             logfile = stderr;
         }
@@ -73,24 +73,24 @@ void Log(LogLevel logType, const char* str, ...)
     }
 
     va_start(args, str);
-    if(fputs(label, logfile) < 0 || vfprintf(logfile, str, args) < 0)
+    if(std::fputs(label, logfile) < 0 || std::vfprintf(logfile, str, args) < 0)
     {
-        fprintf(stderr, "Unable to write to flush info log!");
+        std::fprintf(stderr, "Unable to write to flush info log!");
     }
     else
     {
-        fputc('\n', logfile);
+        std::fputc('\n', logfile);
     }
     va_end(args);
 }
 
 void die(const char* str, ...)
 {
-    va_list args;
-    char    buff[4096];
+    std::va_list args;
+    char         buff[4096];
 
     va_start(args, str);
-    vsnprintf(buff, sizeof(buff), str, args);
+    std::vsnprintf(buff, sizeof(buff), str, args);
     Log(LogLevel::Fatal, buff);
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", buff, nullptr);
     va_end(args);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -25,7 +25,7 @@ Revision History:
 #include "SH3/arc/types.hpp"
 #include "SH3/system/window.hpp"
 #include "SH3/system/config.hpp"
-#include <iostream>
+#include <cstdio>
 
 struct test
 {
@@ -81,11 +81,11 @@ SHSTATUS main(int argc, char** argv)
 
     ret = t1 * t2;
 
-    printf("%f\n", ret.y);
+    std::printf("%f\n", ret.y);
 
     ret = t1 + t2;
 
-    printf("%f\n", ret.y);
+    std::printf("%f\n", ret.y);
 
 //    sh3_config config;
 //    sh3_arc arc;


### PR DESCRIPTION
It working without it is a C relic, not guaranteed to work in C++.

Also includes some more headers in places where they were missing.