### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,37 +42,8 @@ include/glm
 include/SDL2
 include/ft2build.h
 
-
-### All the settings in this below were came from GitHub official GitIgnore repo
-### See here: https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
-
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/
-cmake-build-debug/
-.gitignore.swp
-
-## File-based project format:
-*.iws
-
-## Plugin-specific files:
-
-# IntelliJ
-/out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
-
+#SILENT HILL 3 stuff
+*.arc
+*.000
+*.afs
 


### PR DESCRIPTION
Updated .gitignore so that it is possible to have all SH3 assets in the
project's /data/ directory without git wanting to add them