### PR TITLE
Fixed assert problem

### DIFF
--- a/source/SH3/arc/file.cpp
+++ b/source/SH3/arc/file.cpp
@@ -94,7 +94,7 @@ Return Type:
 --*/
 std::size_t sh3_arc_file::ReadData(void* destination, std::size_t len, read_error& e)
 {
-    assert(std::numeric_limits<int>::max() <= len); // overflow check
+    assert(std::numeric_limits<int>::max() >= len); // overflow check
     int ilen = static_cast<int>(len);
 
     int res = gzread(gzHandle.get(), destination, static_cast<unsigned>(ilen));


### PR DESCRIPTION
sh3_arc_file::ReadData() was checking if the length of data to read was
GREATER than the max size of an int, hence causing an assertion fail.