### PR TITLE
Initial implementaiton of Virtual Files

### DIFF
--- a/include/SH3/arc/vfile.hpp
+++ b/include/SH3/arc/vfile.hpp
@@ -1,0 +1,98 @@
+/** @file
+ *
+ *  Class and data structures describing a Virtual File inside a SILENT HILL 3 arc section.
+ *
+ *  @copyright 2016  Palm Studios
+ *
+ *  @date 5-1-2017
+ *
+ *  @author Jesse Buhagiar
+ */
+#ifndef VFILE_HPP_INCLUDED
+#define VFILE_HPP_INCLUDED
+
+#include "SH3/arc/types.hpp"
+#include "SH3/error.hpp"
+#include <ios>
+
+/**
+ *  Opens a handle to a Virtual File contained within arc.arc
+ *
+ *  After the handle to the file is open, it is possible to seek and rewind
+ *  to a specific part of the file using @ref Seek().
+ *
+ *  Each read sets the @ref read_error indicating whether a partial read was performed,
+ *  or that the end of file was encountered (meaning that @ref fpos `+ len` was equal to @ref fsize.
+ *
+ */
+struct sh3_arc_vfile final
+{
+public:
+    /**
+     *  Failure codes for @ref ReadData.
+     */
+    enum class load_result
+    {
+        SUCCESS,
+        END_OF_FILE,
+        PARTIAL_READ,
+    };
+
+    struct read_error final : public error<load_result>
+    {
+    public:
+        std::string message() const;
+    };
+
+
+    sh3_arc_vfile(sh3_arc& mft, const std::string& fname): fpos(0)
+    {Open(mft, fname);}
+
+    /**
+     *  Read @c len bytes of data into a destination buffer.
+     *
+     *  @param destination      Pointer to write read values into.
+     *  @param len              Number of bytes to read from the file.
+     *  @param e                @ref read_error from this operation.
+     *
+     *  @returns Number of bytes read (which should be len)
+     */
+    std::size_t ReadData(void* destination, std::size_t len, read_error& e);
+
+    /**
+     *  Rewind this file to the beginning (set fpos to 0).
+     */
+    void Rewind(){fpos = 0;};
+
+    /**
+     *  Seek to a certain position in the file.
+     *
+     *  @param pos      Position to seek to.
+     *  @param origin   The origin we want to seek from.
+     */
+     void Seek(long pos, std::ios_base::seekdir origin);
+
+
+private:
+    std::uint32_t   fpos;           /**< Current file position */
+    std::size_t     fsize;          /**< Size of this file inside the arc section in bytes */
+    std::string     fname;          /**< The name of this file (taken from arc.arc) */
+    bool            open = false;   /**< Is this file handle currently open? */
+
+    std::vector<std::uint8_t> buffer; /**< Buffer that @ref ReadData() reads from */
+
+    /**
+     *  Open a handle to a virtual file.
+     *
+     *  @param mft      The @ref sh3_arc Master File Table, arc.arc.
+     *  @param fname    The name of the file we want to open.
+     *
+     *  @note If the file is already open, this function returns false.
+     *
+     *  @returns @c true if the file was found, @c false if not.
+     */
+    bool Open(sh3_arc& mft, const std::string& fname);
+};
+
+
+#endif // VFILE_HPP_INCLUDED

--- a/source/SH3/arc/vfile.cpp
+++ b/source/SH3/arc/vfile.cpp
@@ -1,0 +1,92 @@
+/** @file
+ *
+ *  Implementation of sh3_arc_vfile.hpp
+ *
+ *  @copyright 2016  Palm Studios
+ *
+ *  @date 5-1-2017
+ *
+ *  @author Jesse Buhagiar
+ */
+#include <SH3/arc/vfile.hpp>
+#include <SH3/arc/types.hpp>
+#include <SH3/system/log.hpp>
+#include <cstring>
+#include <cassert>
+
+bool sh3_arc_vfile::Open(sh3_arc& mft, const std::string& fname)
+{
+    if(open) return false;
+
+    /*
+        Load the file from the section it is, and set our local fsize to
+        it (so we know how large it is without probing) though most headers contain the size of the
+        full file
+    */
+    if((fsize = mft.LoadFile(fname, buffer)) == ARC_FILE_NOT_FOUND)
+    {
+        open = false;
+        return open;
+    }
+
+    open = true;
+    return open;
+}
+
+std::string sh3_arc_vfile::read_error::message() const
+{
+    std::string error;
+    switch(result)
+    {
+    case load_result::SUCCESS:
+        error = "Success";
+        break;
+    case load_result::END_OF_FILE:
+        error = "EOF";
+        break;
+    case load_result::PARTIAL_READ:
+        error = "Partial Read";
+        break;
+    }
+    return error;
+};
+
+void sh3_arc_vfile::Seek(long pos, std::ios_base::seekdir origin)
+{
+    if(origin == std::ios_base::beg)
+    {
+        fpos = pos;
+    }
+    else if(std::ios_base::cur)
+    {
+        fpos += pos;
+    }
+
+    // Log if there is an attempt at something naughty
+    if(pos > fsize)
+    {
+        Log(LogLevel::WARN, "sh3_arc_vfile::Seek( ): Attempt to seek to position > fsize! Setting fpos to 0!");
+        fpos = 0;
+    }
+}
+
+std::size_t sh3_arc_vfile::ReadData(void* destination, std::size_t len, read_error& e)
+{
+    if(len >= buffer.size())
+    {
+        e.set_error(load_result::END_OF_FILE);
+    }
+    else if(len < fsize)
+    {
+        e.set_error(load_result::PARTIAL_READ);
+    }
+
+    assert(fpos > fsize); // This should never EVER happen. Terminate if it does.
+
+    std::size_t nbytes = std::min(len, fsize - fpos);
+    std::memcpy(destination, buffer.data() + fpos, nbytes);
+
+    fpos += nbytes; // Increment the position we are at in this file
+
+    return nbytes;
+}


### PR DESCRIPTION
Title explains it all. These are supposed to somewhat mimic C file IO,
as some file types will need to be seeked (Mesh files, animation files
etc). I think this makes a nice way to handle Virtual Files from arc
sections.

However, I feel the std::vector buffer may be a waste of space, and
there could be a MUCH better way to do this without buffering the entire
file (a HUGE waste of memory).

@z33ky There's probably a much better C++ whizbang way to do this (without the chance of any segfaults + more abstractions), but I think this is pretty sound for now, at least for the file types that I know about, especially when it comes to buffering sound.