### PR TITLE
Fixed 'texture.hpp' compile error

### DIFF
--- a/include/SH3/graphics/texture.hpp
+++ b/include/SH3/graphics/texture.hpp
@@ -100,7 +100,7 @@ namespace sh3_graphics
          * @return @ref load_result indicating whether the read failed or not
          *
          */
-        load_error Load(const std::string& filename, sh3_arc& arc);
+        load_result Load(const std::string& filename, sh3_arc& arc);
 
     private:
         static constexpr std::uint32_t INVALID_TEXTURE = std::numeric_limits<uint32_t>::max();


### PR DESCRIPTION
Fixed a stupid error where I had 'load_error' as the return type for
load, when it should have been 'load_result', resulting in a 'No
function to call' compile error.