### PR TITLE
Fix sh3_arc::LoadFile for files not found

### DIFF
--- a/source/SH3/arc/types.cpp
+++ b/source/SH3/arc/types.cpp
@@ -98,7 +98,7 @@ int sh3_arc::LoadFile(const std::string& filename, std::vector<std::uint8_t>& bu
     for(sh3_arc_section& candidate : c_sections)
     {
         auto files = candidate.fileList.equal_range(filename);
-        if(files.first == end(candidate.fileList))
+        if(files.first == files.second)
         {
             continue; // No filename found in this section, continue over
         }


### PR DESCRIPTION
This fixes #68.

`equal_range` returns two iterators, the first of which points to an elements that is "not smaller than" the key, i.e. it may just point to the next entry, and not necessarily to `end()`.
So instead of comparing to `end()`, we compare to the second iterator returned, which points to an element greater than the key.
In case the key is greater than all keys in the map this will still work, as both iterators will be `end()`.