### PR TITLE
Added getter to 'fsize' in vfile.hpp

### DIFF
--- a/include/SH3/arc/vfile.hpp
+++ b/include/SH3/arc/vfile.hpp
@@ -77,6 +77,11 @@ public:
       */
       void Dump2Disk();
 
+     /**
+      * Get the size of this file (in bytes)
+      */
+      size_t GetFilesize() const {return fsize;}
+
 
 private:
     std::size_t     fpos;           /**< Current file position */


### PR DESCRIPTION
Added a getter to vfile, as it was not possible to access the file size, therby making it impossible to read a file in full.