### PR TITLE
Reworked Base texture class

### DIFF
--- a/include/SH3/graphics/texture.hpp
+++ b/include/SH3/graphics/texture.hpp
@@ -97,8 +97,6 @@ namespace sh3_graphics
 
     private:
         GLuint tex;                         /**< ID representing this texture */
-
-        std::vector<std::uint8_t> data;     /**< Pixel data of this texture (with the header stripped) */
     };
 }
 

--- a/include/SH3/graphics/texture.hpp
+++ b/include/SH3/graphics/texture.hpp
@@ -8,21 +8,21 @@
             all of the file types, including all of the textures, meshes and even the motion capture
             skeletal animation that Konami captured. Thanks mate!
  *
- *  @date 2/1/2017
+ *  @note 8-bit textures are currently unsupported, as they are palletted. See <a href=https://www.reddit.com/r/REGames/comments/5kp62x/help_reverse_engineering_silent_hill_3_texture/?st=iyn04asn&sh=92f998d9>here</a>
+ *
+ *  @date 2-1-2017
  *
  *  @author Jesse Buhagiar
  */
 #ifndef SH3_TEXTURE_HPP_INCLUDED
 #define SH3_TEXTURE_HPP_INCLUDED
 
-#include <SH3/arc/types.hpp>
+#include "SH3/arc/types.hpp"
+#include "SH3/arc/vfile.hpp"
 
-#include <cstdint>
-#include <limits>
-#include <vector>
+#include <GL/glew.h>
 #include <GL/gl.h>
 
-#include "SH3/error.hpp"
 
 namespace sh3_graphics
 {
@@ -35,29 +35,29 @@ namespace sh3_graphics
      *
      * Both batch and individual texture.
      */
-    typedef struct
+    struct sh3_texture_header
     {
-        std::uint32_t batchHeaderMarker;   /**< This should be 0xFFFFFFFF to mark a header chunk */
-        std::uint8_t  unused1[4];          /**< There are a lot of unused DWORDs, I assume to align everything nicely */
-        std::uint32_t batchHeaderSize;     /**< Size of the first part of the whole header */
-        std::uint32_t batchSize;           /**< = res * res * (bpp/8) * #tex + 128 * #tex */
-        std::uint8_t  unused2[4];          /**< Unused **/
-        std::uint32_t numBatchedTextures;  /**< Number of textures in this texture file */
-        std::uint8_t  unused3[8];          /**< Unused **/
-        std::uint32_t texHeaderSegMarker;  /**< Secondary texture marker. This signifies the start of the texture information header. This is also 0xFFFFFFFF */
-        std::uint8_t  unused4[4];          /**< Unused **/
-        std::uint16_t texWidth;            /**< The width of this texture */
-        std::uint16_t texHeight;           /**< The height of this texture */
-        std::uint8_t  bpp;                 /**< Number of bits per pixel of this texture. NOTE: 8bpp is believed to be paletted! */
-        std::uint8_t  dataOffset;          /**< #bytes from texHeaderSize+16 to 128 (0 filled) */
-        std::uint8_t  unused5[4];          /**< Unused **/
-        std::uint32_t texSize;             /**< The size of this texture in bytes (w * h * [bpp/8]) */
-        std::uint32_t texHeaderSize;       /**< = texSize + texHeaderSize + 16 + endFilleSize */
-        std::uint8_t  unused6[4];          /**< Unused **/
-        std::uint32_t unknown1;            /**< Completely unknown, probably unimportant for now */
-        std::uint32_t unknown2;            /**< Usually 1! */
-        std::uint32_t unused7[15];         /**< Unused **/
-    } sh3_texture_header;
+        std::uint32_t batchHeaderMarker;    /**< This should be 0xFFFFFFFF to mark a header chunk */
+        std::uint8_t  unused1[4];           /**< There are a lot of unused DWORDs, I assume to align everything nicely */
+        std::uint32_t batchHeaderSize;      /**< Size of the first part of the whole header */
+        std::uint32_t batchSize;            /**< = res * res * (bpp/8) * #tex + 128 * #tex */
+        std::uint8_t  unused2[4];           /**< Unused **/
+        std::uint32_t numBatchedTextures;   /**< Number of textures in this texture file */
+        std::uint8_t  unused3[8];           /**< Unused **/
+        std::uint32_t texHeaderSegMarker;   /**< Secondary texture marker. This signifies the start of the texture information header. This is also 0xFFFFFFFF */
+        std::uint8_t  unused4[4];           /**< Unused **/
+        std::uint16_t texWidth;             /**< The width of this texture */
+        std::uint16_t texHeight;            /**< The height of this texture */
+        std::uint8_t  bpp;                  /**< Number of bits per pixel of this texture. NOTE: 8bpp is believed to be paletted! */
+        std::uint8_t  dataOffset;           /**< #bytes from texHeaderSize+16 to 128 (0 filled) */
+        std::uint8_t  unused5[2];           /**< Unused **/
+        std::uint32_t texSize;              /**< The size of this texture in bytes (w * h * [bpp/8]) */
+        std::uint32_t texFileSize;          /**< = texSize + texHeaderSize + 16 + endFilleSize */
+        std::uint8_t  unused6[4];           /**< Unused **/
+        std::uint32_t unknown1;             /**< Completely unknown, probably unimportant for now */
+        std::uint32_t unknown2;             /**< Usually 1! */
+        std::uint32_t unused7[15];          /**< Unused **/
+    };
 
     /**@}*/
 
@@ -69,47 +69,36 @@ namespace sh3_graphics
      * from a SILENT HILL 3 .arc section.both batch and individual texture
      *
      */
-    class texture
+    struct sh3_texture final
     {
     public:
-        /**
-         *  Failure codes for @ref Load.
-         */
-        enum class load_result
-        {
-            SUCCESS,
-            INVALID_CHUNK,
-            END_OF_FILE,
-        };
-
-        struct load_error final : public error<load_result>
-        {
-        public:
-            std::string message() const;
-        };
-
-        texture(){}
-        texture(const std::string& filename, sh3_arc& arc){Load(filename, arc);}
+        sh3_texture(sh3_arc& mft, const std::string& filename){Load(mft, filename);}
+        ~sh3_texture(){}
 
         /**
-         * Load a texture and return a result to it
+         *  Loads a texture from a Virtual File and creates a logical texture
+         *  on the gpu
          *
-         * @param filename - Virtual file path to file.
-         * @param arc - Reference to sh3_arc (arc.arc)
-         *
-         * @return @ref load_result indicating whether the read failed or not
-         *
+         *  @note Should we scale this ala SILENT HILL 3's "Interal Render Resolution"???
          */
-        load_error Load(const std::string& filename, sh3_arc& arc);
+        void Load(sh3_arc& mft, const std::string& filename);
+
+        /**
+         *  Bind this texture for use with any draw calls
+         *
+         *  @param textureUnit The texture unit we want to bind this texture to
+         */
+        void Bind(GLenum textureUnit);
+
+         /**
+          * Unbind this texture from the
+          */
+         void Unbind();
 
     private:
-        static constexpr std::uint32_t INVALID_TEXTURE = std::numeric_limits<uint32_t>::max();
+        GLuint tex;                         /**< ID representing this texture */
 
-        std::vector<std::uint8_t> pixbuff;
-        std::string               texpath;
-        std::uint32_t             texid = INVALID_TEXTURE;
-
-        sh3_texture_header texheader = {};
+        std::vector<std::uint8_t> data;     /**< Pixel data of this texture (with the header stripped) */
     };
 }
 

--- a/source/SH3/graphics/texture.cpp
+++ b/source/SH3/graphics/texture.cpp
@@ -4,44 +4,69 @@
  *
  *  @copyright 2016  Palm Studios
  *
- *
  *  @date 2-1-2017
  *
  *  @author Jesse Buhagiar
  */
 #include <SH3/graphics/texture.hpp>
 #include <SH3/system/log.hpp>
+#include <SH3/arc/vfile.hpp>
+
+#include <cassert>
+
 
 using namespace sh3_graphics;
 
-std::string texture::load_error::message() const
+//TODO: Scale the texture and then
+void sh3_texture::Load(sh3_arc& mft, const std::string& filename)
 {
-    std::string error;
-    switch(result)
+    sh3_texture_header header;
+    sh3_arc_vfile file(mft, filename);
+    sh3_arc_vfile::read_error e;
+
+    std::size_t ret = file.ReadData(&header, sizeof(header), e); // Read in the header
+
+    if(ret != sizeof(header))
+        die("sh3_texture::Load( ): Header only read %d bytes of data! It should have been %d", ret, sizeof(header)); // TODO: Fallback on dummy texture (like Source's purple and black checkboard)
+
+    if(header.bpp == 8)
+        Log(LogLevel::WARN, "WARNING: 8-bit textures are currently unsupported! They WILL look like nothing but pixel garbage.");
+
+    Log(LogLevel::INFO, "Texture info:\n\ttexWidth:%d\n\ttexHeight:%d\n\ttexSize:%d\n\tbpp:%d", header.texWidth, header.texHeight, header.texSize, header.bpp);
+
+    file.Seek(sizeof(header) + header.dataOffset, std::ios_base::beg);
+
+    data.resize(header.texSize);
+
+    if(header.texSize == header.texWidth * header.texHeight * header.bpp)
+        ret = file.ReadData(&data[0], header.texSize, e);
+    else
     {
-    case load_result::SUCCESS:
-        error = "Success";
-        break;
-    case load_result::INVALID_CHUNK:
-        error = "Invalid chunk";
-        break;
-    case load_result::END_OF_FILE:
-        error = "End of file";
-        break;
-    }
-    return error;
-};
-
-texture::load_error sh3_graphics::texture::Load(const std::string& filename, sh3_arc& arc)
-{
-    load_error error;
-
-    if(arc.LoadFile(filename, pixbuff) == ARC_FILE_NOT_FOUND)
-    {
-        die("sh3_graphics::texture::Load( ): Unable to find file %s!", filename.c_str());
+        Log(LogLevel::ERROR, "sh3_texture::Load( ): texWidth * texHeight * bpp != header.texSize!");
+        return;
     }
 
-    error.set_error(load_result::END_OF_FILE);
+    if(ret != header.texSize)
+        Log(LogLevel::WARN, "sh3_texture::Load( ): Only read %d out of %d bytes!", ret, header.texSize);
 
-    return error;
+    // Now actually create a logical texture with OpenGL on the gpu
+    glGenTextures(1, &tex);
+
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, header.texWidth, header.texHeight, 0, GL_BGRA, GL_UNSIGNED_BYTE, &data[0]);
+    glBindTexture(GL_TEXTURE_2D, 0); // Unbind this texture
 }
+
+void sh3_texture::Bind(GLenum textureUnit)
+{
+    assert(textureUnit >= GL_TEXTURE0 && textureUnit <= GL_TEXTURE31);
+
+    glActiveTexture(textureUnit);
+    glBindTexture(GL_TEXTURE_2D, tex);
+}
+
+void sh3_texture::Unbind()
+{
+    glBindTexture(GL_TEXTURE_2D, 0);
+}
+

--- a/source/SH3/graphics/texture.cpp
+++ b/source/SH3/graphics/texture.cpp
@@ -20,9 +20,10 @@ using namespace sh3_graphics;
 //TODO: Scale the texture and then
 void sh3_texture::Load(sh3_arc& mft, const std::string& filename)
 {
-    sh3_texture_header header;
-    sh3_arc_vfile file(mft, filename);
-    sh3_arc_vfile::read_error e;
+    sh3_texture_header          header;
+    sh3_arc_vfile               file(mft, filename);
+    sh3_arc_vfile::read_error   e;
+    std::vector<std::uint8_t>   data;     // Pixel data of this texture (with the header stripped)
 
     std::size_t ret = file.ReadData(&header, sizeof(header), e); // Read in the header
 
@@ -38,14 +39,13 @@ void sh3_texture::Load(sh3_arc& mft, const std::string& filename)
 
     data.resize(header.texSize);
 
-    if(header.texSize == header.texWidth * header.texHeight * header.bpp)
-        ret = file.ReadData(&data[0], header.texSize, e);
-    else
+    if(header.texSize != header.texWidth * header.texHeight * header.bpp)
     {
         Log(LogLevel::ERROR, "sh3_texture::Load( ): texWidth * texHeight * bpp != header.texSize!");
         return;
     }
 
+    ret = file.ReadData(&data[0], header.texSize, e);
     if(ret != header.texSize)
         Log(LogLevel::WARN, "sh3_texture::Load( ): Only read %d out of %d bytes!", ret, header.texSize);
 


### PR DESCRIPTION
Textures can now be bound for operations by OpenGL, as well as the
ability to be loaded by the new Virtual File System we have. Textures
are stored as their pixel array in a vector.

Currently, 8-bit textures aren't supported because for reasons that
elude me, they are palletted, and I have no clue as to where the
pallete is (or what data it contains).

The header was also fixed up, as it was missing a 16-bit unused value,
which was distorting the number of bytes passed to the Virtual File
System to load the texture.