### PR TITLE
Slight tweak to sh3_glcontext error handling

### DIFF
--- a/source/SH3/system/glcontext.cpp
+++ b/source/SH3/system/glcontext.cpp
@@ -39,8 +39,7 @@ sh3_glcontext::sh3_glcontext(sh3_window& hwnd)
 
     if(glewInit() != GLEW_OK) // Initialise GLEW!
     {
-        Log(LogLevel::FATAL, "sh3_glcontext::sh3_glcontext( ): GLEW Init failed!");
-        std::exit(-1);
+        die("sh3_glcontext::sh3_glcontext( ): GLEW Init failed! (Does your Graphics Driver support OpenGL 3.3?)");
     }
 
     // Set the colour size for OpenGL!


### PR DESCRIPTION
GLEW init failure now uses die(...) instead of just logging, aborting and returning -1 (which would most certainly confuse a user that isn't a programmer). 