### PR TITLE
Fixed Dump2Disk( ) for better file analysis

### DIFF
--- a/source/SH3/arc/vfile.cpp
+++ b/source/SH3/arc/vfile.cpp
@@ -113,7 +113,7 @@ void sh3_arc_vfile::Dump2Disk()
     // Firstly, we need to convert the file path to just the filename.
     std::size_t pos = fname.rfind('/');
 
-    std::ofstream out_file(fname.substr(pos + 1, fname.size()));
+    std::ofstream out_file(fname.substr(pos + 1, fname.size()), std::ios::binary);
     if(!out_file)
         return;
 


### PR DESCRIPTION
Dump2Disk( ) has now been fixed and will output all files correctly. The
std::ofstream on vfile.cpp:116 was _not_ being opened in
std::ios::binary mode, meaning there was some bizarre padding/corrupt
bytes being inserted into the output (on the order of kilobytes). It has
now been corrected.

@z33ky I can't believe neither of us spotted this...