### PR TITLE
Added way to calculate Projection Matrix

### DIFF
--- a/include/SH3/system/glcontext.hpp
+++ b/include/SH3/system/glcontext.hpp
@@ -1,7 +1,7 @@
 /** @file
  *  Defines a logical OpenGL Context
  *
- *  @copyright 2016  Palm Studios
+ *  @copyright 2016-2017 Palm Studios
  *
  *  @date 22-12-2016
  *
@@ -15,57 +15,76 @@
 #include <memory>
 #include <vector>
 #include <GL/glew.h>
+#include <glm/glm.hpp>
+
 #include "SH3/system/sdl_destroyer.hpp"
 
 class sh3_window;
 
-class sh3_glcontext
+namespace sh3_gl
 {
-public:
-    explicit sh3_glcontext(sh3_window& hwnd);
+    class context
+    {
+    public:
+        explicit context(sh3_window& hwnd);
 
-    /**
-     *  Return the vendor of OpenGL Driver in use.
-     */
-    const char* GetVendor() const;
+       /**
+        *  Return the vendor of OpenGL Driver in use.
+        */
+        const char* GetVendor() const;
 
-    /**
-     *  Get the version string of the OpenGL context currently in use.
-     *
-     *  @return OpenGL Version String.
-     */
-    const char* GetVersion() const;
+       /**
+        *  Get the version string of the OpenGL context currently in use.
+        *
+        *  @return OpenGL Version String.
+        */
+        const char* GetVersion() const;
 
-    /**
-     *  Get the name of the renderer.
-     *
-     *  @return OpenGL Renderer name (Graphics Card name)
-     */
-    const char* GetRenderer() const;
+       /**
+        *  Get the name of the renderer (Graphics Card that created this context).
+        *
+        *  @return OpenGL Renderer name (Graphics Card name).
+        */
+        const char* GetRenderer() const;
 
-    /**
-     *  Get a list of all extensions supported by the user's graphics card.
-     */
-    void GetExtensions();
+       /**
+        *  Get a list of all extensions supported by the user's graphics card.
+        */
+        void GetExtensions();
 
-    /**
-     *  Print out information about the current GL Context.
-     */
-    void PrintInfo() const;
+       /**
+        *  Print out information about the current GL Context.
+        */
+        void PrintInfo() const;
 
-private:
+       /**
+        *   Calculate our projection matrix (how we project vertices on the Z plane on the 2D screen).
+        *   Note that OpenGL has +Z coming TOWARDS the user, which is slightly unintuitive, as it means
+        *   each vertex must have its' Z value inverted.
+        *
+        *   @param fov - The Field Of View (FOV) of our Viewing Frustum. Defined in @ref sh3_graphics::camera.
+        *   @param near - The near plane of our Viewing Frustum, i.e, when objects will disappear.
+        *   @param far - The far plane of our Viewing Frustum, i.e, when far objects will disappear (SH fog etc).
+        *
+        *   @return glm::mat4 - 4 float matrix we send to our GLSL program.
+        */
+        glm::mat4 GetProjectionMatrix(float fov, int width, int height, float near, float far);
 
-    /**
-     *  Get a string from the current GL Context.
-     *
-     *  @return String from @c glGetString
-     */
-    static const char* GlGetString(GLenum name);
+    private:
 
-private:
-    std::unique_ptr<flat_sdl_glcontext, sdl_destroyer> glContext;
-    std::vector<const char*> extensions;
+       /**
+        *  Get a string from the current GL Context.
+        *
+        *  @param name - Name of symbolic constant we want to get from the driver.
+        *
+        *  @return char* from @c glGetString.
+        */
+        static const char* GlGetString(GLenum name);
 
-};
+    private:
+        std::unique_ptr<flat_sdl_glcontext, sdl_destroyer> glContext;   /**< A pointer to our actual OpenGL Context */
+        std::vector<const char*> extensions;                            /**< List of all extensions supported by this OpenGL Driver */
+    };
+}
 
 #endif // SH3_GLCONTEXT_HPP_INCLUDED

--- a/include/SH3/system/window.hpp
+++ b/include/SH3/system/window.hpp
@@ -25,10 +25,11 @@ private:
 public:
     sh3_window(int width, int height, const std::string& title);
 
-    std::unique_ptr<SDL_Window, sdl_destroyer> hwnd;
+    std::unique_ptr<SDL_Window, sdl_destroyer> hwnd;        /**< Our window handle */
+    sh3_gl::context context;                                /**< This window's OpenGL Context */
 
 private:
-    sh3_glcontext context; /**< This window's OpenGL Context */
+
 };
 
 #endif // SH3_WINDOW_HPP_INCLUDED

--- a/source/SH3/system/glcontext.cpp
+++ b/source/SH3/system/glcontext.cpp
@@ -1,23 +1,14 @@
-/*++
-
-Copyright (c) 2016  Palm Studios
-
-Module Name:
-        sh3_glcontext.cpp
-
-Abstract:
-        Implementation of sh3_glcontext.hpp
-
-Author:
-        Jesse Buhagiar
-
-Environment:
-
-Notes:
-
-Revision History:
-        22-12-2016: File Created                                        [jbuhagiar]
---*/
+/** @file
+ *
+ *  Implementation of glcontext.hpp
+ *
+ *  @copyright 2016-2017 Palm Studios
+ *
+ *  @date 22-12-2016
+ *
+ *
+ *  @author Jesse Buhagiar
+ */
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -29,8 +20,11 @@ Revision History:
 #include <GL/glew.h>
 #include <GL/glu.h>
 #include <GL/glext.h>
+#include <glm/gtc/matrix_transform.hpp>
 
-sh3_glcontext::sh3_glcontext(sh3_window& hwnd)
+using namespace sh3_gl;
+
+context::context(sh3_window& hwnd)
 {
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
@@ -54,70 +48,22 @@ sh3_glcontext::sh3_glcontext(sh3_window& hwnd)
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 }
 
-/*++
-
-Routine Description:
-        Gets the GLVENDOR String (i.e Graphics Card Manufacturer)
-
-Arguments:
-        None
-
-Return Type:
-        const char* - GLVENDOR String
-
---*/
-const char* sh3_glcontext::GetVendor() const
+const char* context::GetVendor() const
 {
     return GlGetString(GL_VENDOR);
 }
 
-/*++
-
-Routine Description:
-        Gets the GLVERSION String (minor.major version)
-
-Arguments:
-        None
-
-Return Type:
-        const char*
-
---*/
-const char* sh3_glcontext::GetVersion() const
+const char* context::GetVersion() const
 {
     return GlGetString(GL_VERSION);
 }
 
-/*++
-
-Routine Description:
-        Gets the name of the renderer (Graphics Card that created this context)
-
-Arguments:
-        None
-
-Return Type:
-        const char*
-
---*/
-const char* sh3_glcontext::GetRenderer() const
+const char* context::GetRenderer() const
 {
     return GlGetString(GL_RENDERER);
 }
 
-/*++
-
-Routine Description:
-        Get a list of all the extensions supported by this Context (Supported by the actual GPU[???]).
-
-Arguments:
-        None
-
-Return Type:
-        None
-
---*/
-void sh3_glcontext::GetExtensions()
+void context::GetExtensions()
 {
     GLint numExts;
     GLint i;
@@ -134,19 +80,7 @@ void sh3_glcontext::GetExtensions()
     }
 }
 
-/*++
-
-Routine Description:
-        Prints out information about the OpenGL Context we've created
-
-Arguments:
-        None
-
-Return Type:
-        None
-
---*/
-void sh3_glcontext::PrintInfo() const
+void context::PrintInfo() const
 {
     Log(LogLevel::INFO, "GL_VENDOR:\t %s", GetVendor());
     Log(LogLevel::INFO, "GL_VERSION:\t %s", GetVersion());
@@ -157,19 +91,12 @@ void sh3_glcontext::PrintInfo() const
     std::printf("GL_RENDERER:\t %s\n", GetRenderer());
 }
 
-/*++
-
-Routine Description:
-        Retrieve a C-String via glGetString
-
-Arguments:
-        name - the attribute to retrieve
-
-Return Type:
-        const char*
-
---*/
-const char* sh3_glcontext::GlGetString(GLenum name)
+const char* context::GlGetString(GLenum name)
 {
     return reinterpret_cast<const char*>(glGetString(name));
+}
+
+glm::mat4 context::GetProjectionMatrix(float fov, int width, int height, float near, float far)
+{
+    return glm::perspective(fov, static_cast<float>(width) / static_cast<float>(height), near, far);
 }


### PR DESCRIPTION
Added functionality in the OpenGL context to calculate the current
Projection Matrix according to the Camera's FOV and the current Window's
dimensions, as well as being able to set the near and far values of the
current view frustum (handy for the outdoor Silent Hill level of SH3 and SH2). This may eventually need to be moved, as I don't really see a point in passing the window to any game logic (perhaps to change the Window settings in game, though this is unlike the original).

@z33ky Do you think this should be moved somewhere else?? It seems most devs put it in their 'renderer' (or in our case our context), though we could move it to the main game loop when we get further along with development.