### PR TITLE
Assume ASSERTs hold in release build

### DIFF
--- a/include/SH3/system/assert.hpp
+++ b/include/SH3/system/assert.hpp
@@ -6,9 +6,19 @@
 #ifndef SH3_SYSTEM_ASSHERT_HPP_INCLUDED
 #define SH3_SYSTEM_ASSHERT_HPP_INCLUDED
 
+#if __GNUC__
+#define UNREACHABLE() __builtin_unreachable();
+#elif defined(_MSC_VER)
+#define UNREACHABLE() __assume(0);
+#else
+//error here?
+//trigger UB as a way to signal that optimization is OK?
+#define UNREACHABLE() do {} while(false)
+#endif
+
 #ifndef DOXYGEN
 #ifdef ASSERT_OFF
-#define ASSERT_MSG_IMPL(cond, msg, ignore) static_cast<void>(0)
+#define ASSERT_MSG_IMPL(cond, msg, ignore) do { if(!(cond)) UNREACHABLE(); } while(false)
 #else
 #ifdef __GNUC__
 #define ASSERT_FUNC __PRETTY_FUNCTION__


### PR DESCRIPTION
I'm not sure what the best would be when we use neither gcc, clang or MSVC, as then we don't know how to tell the compiler that something holds true.
As mentioned in the comments, we could generate a compile-time error.
Maybe we could trigger UB, which would allow the compiler to assume the branch never happens.
For now it doesn't do anything special in that case. Maybe that's also the best way to go about it.
We could also try for a `#warning`, which will just error for compilers which do not support this non-standard directive.