### PR TITLE
Fixed up Code::Blocks Project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,12 +36,10 @@
 log.txt
 
 #Folders (so library headers don't get pushed for C::B users!)
-include/freetype
-include/FTGL
 include/GL
 include/glm
 include/SDL2
-include/ft2build.h
+include/boost
 
 #SILENT HILL 3 stuff
 *.arc

--- a/SILENT HILL 3 Redux.cbp
+++ b/SILENT HILL 3 Redux.cbp
@@ -13,7 +13,6 @@
 				<Option compiler="gcc" />
 				<Compiler>
 					<Add option="-march=i686" />
-					<Add option="-std=c++11" />
 					<Add option="-m32" />
 					<Add option="-g" />
 					<Add directory="include" />
@@ -35,7 +34,7 @@
 				<Compiler>
 					<Add option="-march=i686" />
 					<Add option="-O2" />
-					<Add option="-std=c++11" />
+					<Add option="-std=c++14" />
 					<Add option="-m32" />
 					<Add directory="include" />
 				</Compiler>
@@ -55,7 +54,6 @@
 				<Option type="1" />
 				<Option compiler="gcc" />
 				<Compiler>
-					<Add option="-std=c++11" />
 					<Add option="-m64" />
 					<Add option="-g" />
 					<Add directory="include" />
@@ -74,7 +72,6 @@
 				<Option use_console_runner="0" />
 				<Compiler>
 					<Add option="-O2" />
-					<Add option="-std=c++11" />
 					<Add option="-m64" />
 					<Add directory="include" />
 				</Compiler>
@@ -87,11 +84,6 @@
 			</Target>
 		</Build>
 		<Compiler>
-			<Add option="-Wsign-compare" />
-			<Add option="-Wold-style-cast" />
-			<Add option="-Wdeprecated" />
-			<Add option="-Wsign-conversion" />
-			<Add option="-Wconversion" />
 			<Add option="-Wnon-virtual-dtor" />
 			<Add option="-Wundef" />
 			<Add option="-Wfloat-equal" />
@@ -101,6 +93,12 @@
 			<Add option="-pedantic" />
 			<Add option="-Wextra" />
 			<Add option="-Wall" />
+			<Add option="-std=c++14" />
+			<Add option="-Wsign-compare" />
+			<Add option="-Wold-style-cast" />
+			<Add option="-Wdeprecated" />
+			<Add option="-Wsign-conversion" />
+			<Add option="-Wconversion" />
 			<Add option="-fexceptions" />
 		</Compiler>
 		<Unit filename="include/SH3/arc/file.hpp" />
@@ -119,6 +117,8 @@
 		<Unit filename="include/SH3/system/glcontext.hpp" />
 		<Unit filename="include/SH3/system/glprogram.hpp" />
 		<Unit filename="include/SH3/system/glvertarray.hpp" />
+		<Unit filename="include/SH3/system/input.hpp" />
+		<Unit filename="include/SH3/system/input_config.hpp" />
 		<Unit filename="include/SH3/system/log.hpp" />
 		<Unit filename="include/SH3/system/sdl_destroyer.hpp" />
 		<Unit filename="include/SH3/system/window.hpp" />
@@ -146,6 +146,7 @@
 		<Unit filename="source/SH3/system/glcontext.cpp" />
 		<Unit filename="source/SH3/system/glprogram.cpp" />
 		<Unit filename="source/SH3/system/glvertarray.cpp" />
+		<Unit filename="source/SH3/system/input.cpp" />
 		<Unit filename="source/SH3/system/log.cpp" />
 		<Unit filename="source/SH3/system/window.cpp" />
 		<Unit filename="source/main.cpp" />


### PR DESCRIPTION
Fixed up the .gitignore and Code::Blocks project (it now targets c++14 instead of c++11) for anyone that wants to use it instead of CMake.