### PR TITLE
Fix sh3_arc::LoadFile

### DIFF
--- a/source/SH3/arc/types.cpp
+++ b/source/SH3/arc/types.cpp
@@ -142,7 +142,7 @@ int sh3_arc::LoadFile(const std::string& filename, std::vector<std::uint8_t>& bu
     }
 
     // Seek to the file entry and read it
-    sectionFile.seekg(index * sizeof(fileEntry), std::ios_base::cur);
+    sectionFile.seekg(index * sizeof(fileEntry));
     static_assert(std::is_trivially_copyable<decltype(fileEntry)>::value, "must be deserializable through char*");
     sectionFile.read(reinterpret_cast<char*>(&fileEntry), sizeof(fileEntry));
 


### PR DESCRIPTION
I tried loading the file `data/eff_tex/fire00_tr.pic`, which resulted in a 0-sized buffer.
After this change, the buffer is 266416 bytes in size, which seems more realistic. Interpreting the start of the data as a texture header tells us this is one 512x512 texture with 8bpp, which would be 262144 bytes (as is the `texSize` field), so it's that and 4272 bytes extra? `texFileSize` is just 262240. *shrug*