### PR TITLE
Silence most warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHE
 		"-Wundef"
 		"-Wfloat-equal"
 		"-Wunreachable-code"
-		"-Wswitch-default"
+		"-Wswitch-enum"
 		"-Weffc++"
 	)
 	string(REPLACE ";" " " CXX_FLAGS "${CXX_FLAGS}")

--- a/SILENT HILL 3 Redux.cbp
+++ b/SILENT HILL 3 Redux.cbp
@@ -88,7 +88,7 @@
 			<Add option="-Wundef" />
 			<Add option="-Wfloat-equal" />
 			<Add option="-Wunreachable-code" />
-			<Add option="-Wswitch-default" />
+			<Add option="-Wswitch-enum" />
 			<Add option="-Weffc++" />
 			<Add option="-pedantic" />
 			<Add option="-Wextra" />

--- a/include/SH3/error.hpp
+++ b/include/SH3/error.hpp
@@ -46,6 +46,7 @@ struct error
 {
 protected:
     error() = default;
+    error(const error&) = default;
     ~error() = default;
 
 public:

--- a/include/SH3/graphics/msbmp.hpp
+++ b/include/SH3/graphics/msbmp.hpp
@@ -106,16 +106,16 @@ namespace sh3_graphics
         /**
          *  Get the width of this texture
          */
-        std::int32_t GetWidth() const {return width;}
+        GLsizei GetWidth() const {return width;}
 
         /**
          *  Get the height of this texture
          */
-        std::int32_t GetHeight() const {return height;}
+        GLsizei GetHeight() const {return height;}
 
     private:
-        std::int32_t width;     /**< Width of this texture in pixels */
-        std::int32_t height;    /**< Height of this texture in pixels */
+        GLsizei width;  /**< Width of this texture in pixels */
+        GLsizei height; /**< Height of this texture in pixels */
 
         /*============OPENGL STUFF============*/
         GLuint tex; /**< Texture ID for this bmp */

--- a/include/SH3/graphics/quad.hpp
+++ b/include/SH3/graphics/quad.hpp
@@ -30,7 +30,7 @@ namespace sh3_graphics
          *  Class constructor. Takes
          */
         quad(const std::array<vertex3f, 6>& verts);
-        ~quad(){};
+        ~quad(){}
 
         /**
          *  Draw this quad to the screen

--- a/include/SH3/system/assert.hpp
+++ b/include/SH3/system/assert.hpp
@@ -15,6 +15,14 @@
 #define UNREACHABLE() do {} while(false)
 #endif
 
+#ifdef __clang__
+#define IGNORE_WARN_ON _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") _Pragma("clang diagnostic ignored \"-Wtautological-compare\"")
+#define IGNORE_WARN_OFF _Pragma("clang diagnostic pop")
+#else
+#define IGNORE_WARN_ON
+#define IGNORE_WARN_OFF
+#endif
+
 #ifndef DOXYGEN
 #ifdef ASSERT_OFF
 #define ASSERT_MSG_IMPL(cond, msg, ignore) do { if(!(cond)) UNREACHABLE(); } while(false)
@@ -27,7 +35,7 @@
 #define ASSERT_FUNC __func__
 #endif
 
-#define ASSERT_MSG_IMPL(cond, msg, ignore) do {static bool assertIgnore = false; if(!assertIgnore && !(cond)) { if(ignore) assertIgnore = true; sh3_assert(assertIgnore, msg, __FILE__, __LINE__, ASSERT_FUNC); } } while(false)
+#define ASSERT_MSG_IMPL(cond, msg, ignore) do { static bool assertIgnore = false; if(!assertIgnore && !(IGNORE_WARN_ON cond IGNORE_WARN_OFF)) { if(ignore) assertIgnore = true; sh3_assert(assertIgnore, msg, __FILE__, __LINE__, ASSERT_FUNC); } } while(false)
 #endif
 #endif
 

--- a/include/SH3/system/glbuffer.hpp
+++ b/include/SH3/system/glbuffer.hpp
@@ -42,12 +42,12 @@ namespace sh3_gl
          *  as we never actually pass anything to this constructor (as well as never passing a buffer_object to
          *  @ref mutablevao).
          */
-        buffer_object(Target type, const std::string& buffName = ""): buffType(type), name(buffName){Create();};
+        buffer_object(Target type, const std::string& buffName = ""): buffType(type), name(buffName){Create();}
 
         /**
          *  Destructor.
          */
-        ~buffer_object(){/**Release(); FIXME: This causes a segmentation violation (why is this called in the game loop!?!?!)*/};
+        ~buffer_object(){/**Release(); FIXME: This causes a segmentation violation (why is this called in the game loop!?!?!)*/}
 
         /**
          *  Create our buffer and register it with OpenGL.
@@ -63,19 +63,19 @@ namespace sh3_gl
         /**
          *  Give some data to our buffer
          *
-         *  @param data     void pointer to our data.
-         *  @param num      Size (in bytes) of the data we are flushing.
+         *  @param data     Pointer to our data.
+         *  @param dataSize Size (in bytes) of the data we are flushing.
          *  @param usage    The way in which want this data stored (i.e, can we rewrite sections of it?).
          */
-        void BufferData(void* data, std::size_t num, GLenum usage);
+        void BufferData(void* data, GLsizei dataSize, GLenum usage);
 
         /**
          *  Redefines/updates a subset of data stored in this GLBuffer.
          *
-         *  @param data void pointer to our data.
-         *  @param num  Size (in bytes) of the data we are flushing.
+         *  @param data     Pointer to our data.
+         *  @param dataSize Size (in bytes) of the data we are flushing.
          */
-        void BufferSubData(void* data, std::size_t size);
+        void BufferSubData(void* data, GLsizei dataSize);
 
         /**
          *  Bind our buffer for use.
@@ -106,7 +106,7 @@ namespace sh3_gl
          *
          *  @return Number of elements in this GL Buffer.
          */
-        std::uint32_t GetNumberElements() const;
+        GLsizei GetNumberElements() const;
 
         /**
          *  Return the size of this buffer.
@@ -116,10 +116,10 @@ namespace sh3_gl
         std::size_t GetBufferSize() const;
 
     private:
-        GLuint          id;         /**< The ID of our buffer given to us by OpenGL */
-        Target          buffType;   /**< What type of buffer this is */
-        std::size_t     size;       /**< The size of this buffer in bytes */
-        std::string     name;       /**< The name of this buffer */
+        GLuint      id;       /**< The ID of our buffer given to us by OpenGL */
+        Target      buffType; /**< What type of buffer this is */
+        GLsizei     size;     /**< The size of this buffer in bytes */
+        std::string name;     /**< The name of this buffer */
     };
 }
 

--- a/include/SH3/system/glprogram.hpp
+++ b/include/SH3/system/glprogram.hpp
@@ -21,8 +21,6 @@
 #include <string>
 #include <vector>
 
-
-
 namespace sh3_gl
 {
 
@@ -48,20 +46,18 @@ namespace sh3_gl
         private:
         };
 
-        program(const std::string& name, load_error& err, const std::vector<std::string>& attribs = {}) : programName(name){Load(name, err, attribs);};
+        program(const std::string& name, load_error& err, const std::vector<std::string>& attribs = {}) : programName(name){Load(name, err, attribs);}
         ~program(){Unbind(); glDeleteProgram(programID);}
 
         void Load(const std::string& name);
         /**
          *  Load a shader from a file on disk, compile and then link it, binding any attributes in the process.
          *
-         *  @param shader Name of the shader we want to load (path is hard-coded to /data/shaders). Assumes *.vert and *.frag have the same name.
+         *  @param shader  Name of the shader we want to load (path is hard-coded to /data/shaders). Assumes *.vert and *.frag have the same name.
          *  @param attribs Vector of attributes we bind before we link the program.
-         *  @param err Error set by this operation.
-         *
-         *  @return @ref load_error The error set by this operation (specified in the @ref load_result enum)
+         *  @param err     Error set by this operation.
          */
-        void Load(const std::string& shader, load_error& err, const std::vector<std::string>  &attribs = {});
+        void Load(const std::string& shader, load_error& err, const std::vector<std::string> &attribs = {});
 
         /**
          *  Bind this shader program for use.

--- a/include/SH3/system/glvertarray.hpp
+++ b/include/SH3/system/glvertarray.hpp
@@ -40,21 +40,21 @@ namespace sh3_gl{
          *
          *  @param verts Reference to our @ref buffer_object filled with vertex data.
          */
-        finalvao(const buffer_object& verts):ibo(nullptr), vertices(verts)
+        finalvao(const buffer_object& verts):vertices(verts), ibo(nullptr)
         {
             Create();
-        };
+        }
 
         /**
          *  Indexed constructor.
          *
-         *  @param ibo      Reference to our @ref buffer_object filled with vertex <i>indices</i> instead of vertex data.
-         *  @param verts    Reference to our @ref buffer_object filled with vertex data.
+         *  @param indices Reference to our @ref buffer_object filled with vertex <i>indices</i> instead of vertex data.
+         *  @param verts   Reference to our @ref buffer_object filled with vertex data.
          */
-        finalvao(const buffer_object &ibo, const buffer_object& verts):ibo(&ibo), vertices(verts)
+        finalvao(const buffer_object &indices, const buffer_object& verts):vertices(verts), ibo(&indices)
         {
             Create();
-        };
+        }
 
         //No virtual dtor, because finalvao should not be stored directly, i.e. this should only ever be used as a reference.
 
@@ -132,7 +132,7 @@ namespace sh3_gl{
 
     private:
         template<std::size_t... seq>
-        mutablevao(const Targets& targets, const buffer_object& vertices, std::index_sequence<seq...>): finalvao(vertices), buffers({targets[seq]...}) {}
+        mutablevao(const Targets& targets, const buffer_object& vertices, std::index_sequence<seq...>): finalvao(vertices), buffers{{{targets[seq]}...}} {}
 
     public:
         /**
@@ -278,7 +278,7 @@ namespace sh3_gl{
 
     public:
         using DataType = typename vaoparent::DataType;
-        using Slot = enum Attributes::Slot;
+        using Slot = typename Attributes::Slot;
 
         /**
          *  Constructor.

--- a/include/SH3/system/input.hpp
+++ b/include/SH3/system/input.hpp
@@ -497,7 +497,7 @@ namespace sh3 { namespace system {
      */
     inline input_system::action_state::state::simple operator!(const input_system::action_state::state::simple state)
     {
-        return static_cast<input_system::action_state::state::simple>(!state);
+        return static_cast<input_system::action_state::state::simple>(!static_cast<bool>(state));
     }
 
     inline void input_system::action_state::state::Set(const simple state)

--- a/source/SH3/arc/mft.cpp
+++ b/source/SH3/arc/mft.cpp
@@ -368,15 +368,15 @@ namespace {
 
         read_error readError;
 
-        subarc_header header;
-        ReadObject(header, readError);
+        subarc_header sub_header;
+        ReadObject(sub_header, readError);
         if(readError)
         {
             die("E00006: mft_reader::ReadNextSubarc( ): Invalid read of arc.arc subarc: %s!", readError.message().c_str());
         }
 
         std::string subarcName;
-        ReadString(subarcName, header.hsize - sizeof(header), readError);
+        ReadString(subarcName, sub_header.hsize - sizeof(sub_header), readError);
         if(subarcName.back() != '\0')
         {
             die("E00007: mft_reader::ReadNextSubarc( ): Garbage read when reading subarc name (NUL terminator missing): %s!", subarcName.c_str());
@@ -389,7 +389,7 @@ namespace {
         // We have now loaded information about the subarc, so we can start
         // reading in all the files located in it (not in full, obviously...)
         subarc::files_map fileList;
-        for(std::size_t i = 0; i < header.numFiles; ++i)
+        for(std::size_t i = 0; i < sub_header.numFiles; ++i)
         {
             subarc_file_entry file;
             ReadObject(file.header, readError);

--- a/source/SH3/arc/subarc.cpp
+++ b/source/SH3/arc/subarc.cpp
@@ -1,6 +1,5 @@
 #include "SH3/arc/subarc.hpp"
 
-#include <cassert>
 #include <cstdint>
 #include <fstream>
 #include <iterator>
@@ -10,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "SH3/system/assert.hpp"
 #include "SH3/system/log.hpp"
 
 using namespace sh3::arc;
@@ -89,13 +89,13 @@ int subarc::LoadFile(index_t index, std::vector<std::uint8_t>& buffer, std::vect
 
     // Seek to the file entry and read it
     subarc_file_entry fileEntry;
-    assert(index <= std::numeric_limits<std::streamoff>::max() / sizeof(fileEntry));
+    ASSERT(index <= std::numeric_limits<std::streamoff>::max() / sizeof(fileEntry));
     file.seekg(static_cast<std::streamoff>(index * sizeof(fileEntry)));
     static_assert(std::is_trivially_copyable<decltype(fileEntry)>::value, "must be deserializable through char*");
     file.read(reinterpret_cast<char*>(&fileEntry), sizeof(fileEntry));
 
     auto space = distance(start, end(buffer));
-    assert(space >= 0);
+    ASSERT(space >= 0);
     if(space < fileEntry.length)
     {
         using size_type = std::remove_reference<decltype(buffer)>::type::size_type;

--- a/source/SH3/arc/subarc.cpp
+++ b/source/SH3/arc/subarc.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <fstream>
 #include <iterator>
+#include <limits>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -88,7 +89,8 @@ int subarc::LoadFile(index_t index, std::vector<std::uint8_t>& buffer, std::vect
 
     // Seek to the file entry and read it
     subarc_file_entry fileEntry;
-    file.seekg(index * sizeof(fileEntry));
+    assert(index <= std::numeric_limits<std::streamoff>::max() / sizeof(fileEntry));
+    file.seekg(static_cast<std::streamoff>(index * sizeof(fileEntry)));
     static_assert(std::is_trivially_copyable<decltype(fileEntry)>::value, "must be deserializable through char*");
     file.read(reinterpret_cast<char*>(&fileEntry), sizeof(fileEntry));
 

--- a/source/SH3/arc/vfile.cpp
+++ b/source/SH3/arc/vfile.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <cassert>
 #include <fstream>
+#include <limits>
 
 #include "SH3/arc/subarc.hpp"
 #include "SH3/arc/mft.hpp"
@@ -60,7 +61,7 @@ std::string vfile::read_error::message() const
         break;
     }
     return error;
-};
+}
 
 void vfile::Seek(long pos, std::ios_base::seekdir origin)
 {
@@ -122,5 +123,6 @@ void vfile::Dump2Disk() const
     if(!out_file)
         return;
 
-    out_file.write((const char*)&buffer[0], buffer.size());
+    assert(buffer.size() <= std::numeric_limits<std::streamsize>::max());
+    out_file.write(reinterpret_cast<const char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
 }

--- a/source/SH3/graphics/quad.cpp
+++ b/source/SH3/graphics/quad.cpp
@@ -24,7 +24,7 @@ quad::quad(const std::array<vertex3f, 6>& verts)
 
     // Copy the vertices into our buffer
     glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(vertex3f), verts.data(), GL_STATIC_DRAW);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, 0); // 3-floats per vertex, in VAO slot 0 (position/vertex)
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, nullptr); // 3-floats per vertex, in VAO slot 0 (position/vertex)
     glBindVertexArray(0);
 }
 

--- a/source/SH3/system/glbuffer.cpp
+++ b/source/SH3/system/glbuffer.cpp
@@ -11,7 +11,7 @@
 #include "SH3/system/glbuffer.hpp"
 #include "SH3/system/log.hpp"
 
-constexpr int GL_VBO_UNBIND  = 0;
+constexpr GLuint GL_VBO_UNBOUND = 0;
 
 using namespace sh3_gl;
 
@@ -32,23 +32,24 @@ void buffer_object::Bind() const
 
 void buffer_object::Unbind()
 {
-    glBindBuffer(static_cast<GLenum>(buffType), 0);
+    glBindBuffer(static_cast<GLenum>(buffType), GL_VBO_UNBOUND);
 }
 
-void buffer_object::BufferData(void* data, std::size_t num, GLenum usage)
+void buffer_object::BufferData(void* data, GLsizei dataSize, GLenum usage)
 {
     Bind();
-    glBufferData(static_cast<GLenum>(buffType), num, data, usage);
-    size = num;
+    glBufferData(static_cast<GLenum>(buffType), dataSize, data, usage);
+    size = dataSize;
 }
 
-void buffer_object::BufferSubData(void* data, std::size_t size)
+void buffer_object::BufferSubData(void* data, GLsizei dataSize)
 {
+    //ASSERT(dataSize <= size);
     Bind();
-    glBufferSubData(static_cast<GLenum>(buffType), 0, size, data);
+    glBufferSubData(static_cast<GLenum>(buffType), 0, dataSize, data);
 }
 
-std::uint32_t buffer_object::GetNumberElements() const
+GLsizei buffer_object::GetNumberElements() const
 {
-    return size / sizeof(GLfloat); // FIXME: What if we're _not_ using GLfloat!?!?!
+    return size / static_cast<GLsizei>(sizeof(GLfloat)); // FIXME: What if we're _not_ using GLfloat!?!?!
 }

--- a/source/SH3/system/glcontext.cpp
+++ b/source/SH3/system/glcontext.cpp
@@ -65,15 +65,15 @@ const char* context::GetRenderer() const
 void context::GetExtensions()
 {
     GLint numExts;
-    GLint i;
 
     glGetIntegerv(GL_NUM_EXTENSIONS, &numExts); // Get the number of extensions the system supports
-    static_assert(std::numeric_limits<std::size_t>::max() >= std::numeric_limits<GLint>::max(), "std::size_t must be able to represent all positive GLint");
     assert(numExts >= 0);
-    extensions.reserve(static_cast<std::size_t>(numExts));
+    static_assert(std::numeric_limits<GLuint>::max() >= std::numeric_limits<decltype(numExts)>::max(), "GLuint must be able to represent all positive values of numExts");
+    GLuint uNumExts = static_cast<GLuint>(numExts);
+    extensions.reserve(uNumExts);
 
     // Iterate over each extension the graphics card supports and store it
-    for(i = 0; i < numExts; i++)
+    for(GLuint i = 0; i < uNumExts; i++)
     {
         extensions.push_back(reinterpret_cast<const char*>(glGetStringi(GL_EXTENSIONS, i)));
     }

--- a/source/SH3/system/glvertarray.cpp
+++ b/source/SH3/system/glvertarray.cpp
@@ -42,7 +42,7 @@ void finalvao::Draw()
 {
     Bind();
     if(ibo)
-        glDrawElements(GL_TRIANGLES, ibo->GetNumberElements(), GL_UNSIGNED_INT, 0);
+        glDrawElements(GL_TRIANGLES, ibo->GetNumberElements(), GL_UNSIGNED_INT, nullptr);
     else
         glDrawArrays(GL_TRIANGLES, 0, vertices.GetNumberElements());
 }

--- a/source/SH3/system/input.cpp
+++ b/source/SH3/system/input.cpp
@@ -117,10 +117,10 @@ bool input_system::raw::operator==(const raw &other) const
         return keyboardKey == other.keyboardKey;
     case type::MOUSE_BUTTON:
         return mouseButton == other.mouseButton;
-    default:
-        ASSERT(false);
-        return false;
     }
+
+    ASSERT(false);
+    return false;
 }
 
 bool input_system::raw::operator<(const raw &other) const
@@ -136,8 +136,8 @@ bool input_system::raw::operator<(const raw &other) const
         return keyboardKey < other.keyboardKey;
     case type::MOUSE_BUTTON:
         return mouseButton < other.mouseButton;
-    default:
-        ASSERT(false);
-        return false;
     }
+
+    ASSERT(false);
+    return false;
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -51,10 +51,10 @@ public:
     };
 
     static constexpr sh3_gl::vao_target_array<Slot> Targets =
-    {
+    { {
         Target::ARRAY_BUFFER,
         Target::ARRAY_BUFFER
-    };
+    } };
 };
 constexpr sh3_gl::vao_target_array<TriangleAttributes::Slot> TriangleAttributes::Targets;
 

--- a/tests/tex.cpp
+++ b/tests/tex.cpp
@@ -56,10 +56,10 @@ public:
     };
 
     static constexpr sh3_gl::vao_target_array<Slot> Targets =
-    {
+    { {
         Target::ARRAY_BUFFER,
         Target::ARRAY_BUFFER
-    };
+    } };
 };
 constexpr sh3_gl::vao_target_array<QuadAttributes::Slot> QuadAttributes::Targets;
 

--- a/tests/vao.cpp
+++ b/tests/vao.cpp
@@ -47,10 +47,10 @@ public:
     };
 
     static constexpr sh3_gl::vao_target_array<Slot> Targets =
-    {
+    { {
         Target::ARRAY_BUFFER,
         Target::ARRAY_BUFFER
-    };
+    } };
 };
 constexpr sh3_gl::vao_target_array<TriangleAttributes::Slot> TriangleAttributes::Targets;
 


### PR DESCRIPTION
With this PR, only `-Weffc++` warnings remain for gcc (see #111) and spurious `-Wdocumentation` warnings (because it doesn't understand `@see @ref Thing`).