### PR TITLE
Use error struct for sh3::arc::{mft,subarc}::LoadFile

### DIFF
--- a/include/SH3/arc/mft.hpp
+++ b/include/SH3/arc/mft.hpp
@@ -13,11 +13,34 @@
 #include <vector>
 
 #include "SH3/arc/subarc.hpp"
+#include "SH3/system/assert.hpp"
 
 namespace sh3 { namespace arc {
 
     struct mft final
     {
+    public:
+        /**
+         *  An enum representing possible results from trying to load a file.
+         */
+        enum class load_result
+        {
+            SUCCESS,             ///< Success.
+            FILE_NOT_FOUND,      ///< File not found.
+            SUBARC_ERROR,        ///< Error loading the file from the subarc.
+        };
+        struct load_error final : public error<load_result>
+        {
+        public:
+            void set_error(load_result res) { ASSERT(res == load_result::FILE_NOT_FOUND); result = res; }
+            void set_error(subarc::load_error e) { ASSERT(e.get_result() != subarc::load_result::FILE_NOT_FOUND); result = load_result::SUBARC_ERROR; subarcError = e; }
+
+            std::string message() const;
+
+        private:
+            subarc::load_error subarcError;
+        };
+
     public:
         std::vector<subarc> subarcs;    /**< List of all the subarcs in @c arc.arc */
 
@@ -31,10 +54,11 @@ namespace sh3 { namespace arc {
          *  @param filename Path to the file to load.
          *  @param buffer   The buffer to store the file contents into.
          *  @param start    An iterator to the insertion position in @c buffer.
+         *  @param e        @ref load_error from this operation.
          *
          *  @returns  The file length if loading is successful, @ref arcFileNotFound if not.
          */
-        int LoadFile(const std::string& filename, std::vector<std::uint8_t>& buffer, std::vector<std::uint8_t>::iterator& start);
+        std::size_t LoadFile(const std::string& filename, std::vector<std::uint8_t>& buffer, std::vector<std::uint8_t>::iterator& start, load_error &e);
 
         /**
          *  Load a file from an subarc into @c buffer.
@@ -44,10 +68,11 @@ namespace sh3 { namespace arc {
          *
          *  @param filename Path to the file to load.
          *  @param buffer   The buffer to store the file contents into.
+         *  @param e        @ref load_error from this operation.
          *
          *  @returns The file length if loading is successful, @ref arcFileNotFound if not.
          */
-        int LoadFile(const std::string& filename, std::vector<std::uint8_t>& buffer) { auto back = end(buffer); return LoadFile(filename, buffer, back); }
+        std::size_t LoadFile(const std::string& filename, std::vector<std::uint8_t>& buffer, load_error &e) { auto back = end(buffer); return LoadFile(filename, buffer, back, e); }
     };
 
 } }

--- a/include/SH3/error.hpp
+++ b/include/SH3/error.hpp
@@ -62,7 +62,7 @@ public:
      *
      *  @returns The @c result_enum.
      */
-    result_enum get_error() const { return result; }
+    result_enum get_result() const { return result; }
 
     /**
      *  Set the wrapped @c result_enum.

--- a/include/SH3/error.hpp
+++ b/include/SH3/error.hpp
@@ -49,6 +49,9 @@ protected:
     error(const error&) = default;
     ~error() = default;
 
+    error& operator=(const error&) = default;
+    error& operator=(error&&) = default;
+
 public:
     /**
      *  Check if error is present.

--- a/source/SH3/arc/subarc.cpp
+++ b/source/SH3/arc/subarc.cpp
@@ -28,6 +28,8 @@ namespace {
         std::uint32_t numFiles;          /**< Number of files located in this sub .arc */
         std::uint32_t dataPointer;       /**< Pointer to the beginning of the data section */
         std::uint32_t unused;            /**< Unused DWORD */
+
+        static constexpr std::uint32_t expectedMagic = 0x20030507; /**< Expected value of @ref magic. */
     };
 
     /**
@@ -49,15 +51,58 @@ std::ifstream subarc::open(std::ios_base::openmode mode)
     const std::string path = "data/" + name + ".arc";
     return std::ifstream(path, mode);
 }
+ 
+std::string subarc::load_error::message() const
+{
+    std::string error;
+    switch(result)
+    {
+    case load_result::SUCCESS:
+        error = "Success";
+        break;
+    case load_result::SUBARC_NOT_FOUND:
+        error = "Subarc not accessible";
+        break;
+    case load_result::FILE_NOT_FOUND:
+        error = "File not found";
+        break;
+    case load_result::SUBARC_ERROR:
+        error = "Subarc magic mismatch (expected " + std::to_string(subarc_header::expectedMagic) + " got " + std::to_string(magic) + ")";
+        break;
+    case load_result::PARTIAL_READ:
+        error = "Read " + std::to_string(readError.read) + "/" + std::to_string(readError.size) + " bytes before encountering an I/O error";
+        break;
+    case load_result::PARTIAL_HEADER_READ:
+        {
+            std::size_t size;
+            std::string headerName;
+            if(headerReadError.headerType == header::SUBARC)
+            {
+                size = sizeof(subarc_header);
+                headerName = "subarc_header";
+            }
+            else
+            {
+                ASSERT(headerReadError.headerType == header::FILE);
+                size = sizeof(subarc_file_entry);
+                headerName = "subarc_file_entry";
+            }
+            error = "Read " + std::to_string(readError.read) + "/" + std::to_string(size) + " bytes for " + headerName;
+        }
+        break;
+    };
+    return error;
+}
 
-int subarc::LoadFile(const std::string& filename, std::vector<std::uint8_t>& buffer, std::vector<std::uint8_t>::iterator& start)
+std::size_t subarc::LoadFile(const std::string& filename, std::vector<std::uint8_t>& buffer, std::vector<std::uint8_t>::iterator& start, load_error &e)
 {
     using std::next;
 
     auto matching = files.equal_range(filename);
     if(matching.first == matching.second)
     {
-        return arcFileNotFound;
+        e.set_file_not_found_error();
+        return 0;
     }
 
     using std::next;
@@ -68,25 +113,33 @@ int subarc::LoadFile(const std::string& filename, std::vector<std::uint8_t>& buf
         Log(LogLevel::WARN, "Multiple files with name %s exist in subarc %s.", filename.c_str(), name.c_str());
     }
     // match->second is the value of the entry the iterator is pointing at
-    return LoadFile(match->second, buffer, start);
+    return LoadFile(match->second, buffer, start, e);
 }
 
-int subarc::LoadFile(index_t index, std::vector<std::uint8_t>& buffer, std::vector<std::uint8_t>::iterator& start)
+std::size_t subarc::LoadFile(index_t index, std::vector<std::uint8_t>& buffer, std::vector<std::uint8_t>::iterator& start, load_error &e)
 {
     std::ifstream file = open();
     if(!file)
     {
-        die("E00005: subarc::LoadFile( ): Unable to open a handle to section, %s!", name.c_str());
+        e.set_subarc_not_found_error();
+        return 0;
     }
 
     // Read the actual file from the appropriate sub arc
     subarc_header header;
     // Read header to check validity
     file.read(reinterpret_cast<char*>(&header), sizeof(header));
-    static constexpr decltype(header.magic) magic = 0x20030507; /**< Magic number (first 4 bytes) of an subarc header */
-    if(header.magic != magic)
+    if(file.gcount() != sizeof(header))
     {
-        die("subarc::LoadFile( ): Subarc [%s] magic is incorrect! (Perhaps the file is corrupt!?)", name.c_str());
+        ASSERT(file.fail());
+        e.set_partial_header_read_error(load_error::header::SUBARC, static_cast<std::size_t>(file.gcount()));
+        return 0;
+    }
+    if(header.magic != subarc_header::expectedMagic)
+    {
+        //TODO: report read magic
+        e.set_subarc_error(header.magic);
+        return 0;
     }
 
     // Seek to the file entry and read it
@@ -95,21 +148,39 @@ int subarc::LoadFile(index_t index, std::vector<std::uint8_t>& buffer, std::vect
     file.seekg(static_cast<std::streamoff>(index * sizeof(fileEntry)), std::ios_base::cur);
     static_assert(std::is_trivially_copyable<decltype(fileEntry)>::value, "must be deserializable through char*");
     file.read(reinterpret_cast<char*>(&fileEntry), sizeof(fileEntry));
+    if(file.gcount() != sizeof(fileEntry))
+    {
+        ASSERT(file.fail());
+        e.set_partial_header_read_error(load_error::header::FILE, static_cast<std::size_t>(file.gcount()));
+        return 0;
+    }
 
-    auto space = distance(start, end(buffer));
-    ASSERT(space >= 0);
-    if(space < fileEntry.length)
+    const auto prespace = distance(start, end(buffer));
+    ASSERT(prespace >= 0);
+    if(prespace < fileEntry.length)
     {
         using size_type = std::remove_reference<decltype(buffer)>::type::size_type;
-        buffer.resize(fileEntry.length - static_cast<size_type>(space));
+        buffer.resize(buffer.size() - static_cast<size_type>(prespace) + fileEntry.length);
         start = end(buffer) - fileEntry.length;
     }
 
     file.seekg(fileEntry.offset);
     static_assert(std::is_trivially_copyable<std::remove_reference<decltype(*start)>::type>::value, "must be deserializable through char*");
     file.read(reinterpret_cast<char*>(&*start), fileEntry.length);
-    advance(start, fileEntry.length);
+    std::size_t read = static_cast<std::size_t>(file.gcount());
+    ASSERT(read <= fileEntry.length);
+    advance(start, read);
+    if(read != fileEntry.length)
+    {
+        ASSERT(file.fail());
+        e.set_partial_read_error(read, fileEntry.length);
 
-    //FIXME: use error_code pattern like mft_reader::ReadFile
-    return static_cast<int>(fileEntry.length);
+        //undo buffer resizing, if we did resize it before
+        if(prespace < fileEntry.length)
+        {
+            buffer.resize(buffer.size() - (fileEntry.length - read));
+        }
+    }
+
+    return read;
 }

--- a/source/SH3/arc/vfile.cpp
+++ b/source/SH3/arc/vfile.cpp
@@ -30,15 +30,15 @@ bool vfile::Open(mft& mft, const std::string& filename)
         it (so we know how large it is without probing) though most headers contain the size of the
         full file
     */
-    int size = mft.LoadFile(filename, buffer);
-    if(size == arcFileNotFound)
+    mft::load_error e;
+    std::size_t size = mft.LoadFile(filename, buffer, e);
+    if(e)
     {
         open = false;
     }
     else
     {
-        assert(size >= 0);
-        fsize = static_cast<unsigned>(size);
+        fsize = size;
 
         open = true;
     }


### PR DESCRIPTION
We're currently not doing much with the error, but that can be changed easily.
I'm also doing more error checking than before.