### PR TITLE
Moved all pixel types to 'color.hpp'

### DIFF
--- a/include/SH3/types/color.hpp
+++ b/include/SH3/types/color.hpp
@@ -1,0 +1,68 @@
+/** @file
+ *  Macros and structures related to pixel information.
+ *
+ *  @copyright 2016  Palm Studios
+ *
+ *  @date 14-12-2016
+ *
+ *  @author Jesse Buhagiar
+ */
+#ifndef COLOR_HPP_INCLUDED
+#define COLOR_HPP_INCLUDED
+
+#include <GL/gl.h>
+#include <cstdint>
+#include <cstddef>
+
+/** @defgroup graphics-types Graphics Types
+ *  @{
+*/
+
+/**
+ *  RGBA pixel
+ */
+struct rgba
+{
+    std::uint8_t r, g, b, a;
+};
+
+/*
+ *  RGBA16 pixel
+ */
+struct rgba16
+{
+    std::uint8_t r : 5;
+    std::uint8_t g : 5;
+    std::uint8_t b : 5;
+    std::uint8_t a : 1;
+};
+
+/**
+ *  RGB24 pixel
+ */
+struct rgb
+{
+    std::uint8_t r, g, b;
+};
+
+/**
+ * BGRA pixel (swizzled RGBA)
+ */
+struct bgra
+{
+    std::uint8_t b, g, r, a;
+};
+
+/**
+ *  BGR24 pixel (swizzled RGB24)
+ */
+struct bgr
+{
+    std::uint8_t b, g, r;
+};
+
+static_assert(offsetof(struct rgb, b) == 2* sizeof(std::uint8_t), "struct has been padded on this compiler! (mingw/win32 use '-mno-ms-bitfields!')");
+
+/**@}*/
+
+#endif // COLOR_HPP_INCLUDED

--- a/source/SH3/graphics/texture.cpp
+++ b/source/SH3/graphics/texture.cpp
@@ -13,6 +13,7 @@
 #include <SH3/system/log.hpp>
 #include <SH3/arc/mft.hpp>
 #include <SH3/arc/vfile.hpp>
+#include <SH3/types/color.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -23,35 +24,11 @@
 
 using namespace sh3_graphics;
 
+/** @defgroup graphics-types Graphics Types
+ *  @{
+*/
+
 #pragma pack(push, 1)
-struct rgba
-{
-    std::uint8_t r, g, b, a;
-};
-
-struct rgba16
-{
-    std::uint8_t r : 5;
-    std::uint8_t g : 5;
-    std::uint8_t b : 5;
-    std::uint8_t a : 1;
-};
-
-struct rgb
-{
-    std::uint8_t r, g, b;
-};
-
-struct bgra
-{
-    std::uint8_t b, g, r, a;
-};
-
-struct bgr
-{
-    std::uint8_t b, g, r;
-};
-
 struct tga_header
 {
     static constexpr std::uint8_t TYPE_RGB24 = 2;
@@ -69,8 +46,9 @@ struct tga_header
     std::uint8_t bpp = 24;                  /**< Bits per pixel */
     std::uint8_t flags = FLAGS_FLIP;
 };
-
 #pragma pack(pop)
+
+/**@}*/
 
 namespace
 {


### PR DESCRIPTION
Considering these types need to be used elsewhere besides textures (such as vertex data) these types have been moved to their own header under 'SH3/types/'