### PR TITLE
Start port to Bash

### DIFF
--- a/sh3rd.sh
+++ b/sh3rd.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find . -executable -exec {} \;


### PR DESCRIPTION
We should leave memory-unsafe languages like C++ in our past.
First I thought about using Rust, but even that provides an easy-to-use escape hatch, `unsafe`.
Instead I've opted to using Bash, a proper memory-safe language.

The porting effort should start piece-by-piece, replacing one C++-module at a time. So the first step simply replaces the need to start the binary directly with a Bash script. As a safety measure it starts all binaries it finds in the hopes that at least one of them is SH3 Redux.