### PR TITLE
Fixed build error due to camera.cpp

### DIFF
--- a/source/SH3/camera/camera.cpp
+++ b/source/SH3/camera/camera.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <boost/algorithm/clamp.hpp>
 
-static constexpr glm::vec3 worldUp = glm::vec3(0, 1, 0); /**< Which axis is considered 'world up'. */
+static const glm::vec3 worldUp = glm::vec3(0, 1, 0); /**< Which axis is considered 'world up'. */
 
 sh3::camera::Camera::Camera(const glm::vec3& pos, angle<float> fov, float aspect, float zNear, float zFar)
 : camPos(pos), camFov(fov), aRatio(aspect), camNear(zNear), camFar(zFar),


### PR DESCRIPTION
Fixed the following error in gcc:

`error: call to non-'constexpr' function 'glm::vec<3, T, Q>::vec(X, Y, Z) [with X = int; Y = int; Z = int; T = float; glm::qualifier Q = (glm::qualifier)0]'`

This is due to the `constexpr` keyword being incompatible with SIMD
compiler intrinsics.