### PR TITLE
Basic state based game system

### DIFF
--- a/include/SH3/engine/engine.hpp
+++ b/include/SH3/engine/engine.hpp
@@ -18,6 +18,7 @@
 #include "SH3/common/singleton.hpp"
 #include "SH3/system/config.hpp"
 #include "SH3/system/clock.hpp"
+#include "SH3/engine/statemanager.hpp"
 
 #include <string>
 #include <cstdint>
@@ -63,9 +64,10 @@ private:
     void Run(void) noexcept;
 
 private:
-    sh3_config              config;         /**< The engine's configuration file */
-    bool                    running;        /**< Is the game currently running? */
-    sh3::system::clock_t    clock;          /**< Game clock (for loop timing)*/
+    sh3_config                  config;         /**< The engine's configuration file */
+    bool                        running;        /**< Is the game currently running? */
+    sh3::system::clock_t        clock;          /**< Game clock (for loop timing)*/
+    sh3::state::CStateManager   stateManager;
 };
 
 }}

--- a/include/SH3/engine/gamestate.hpp
+++ b/include/SH3/engine/gamestate.hpp
@@ -1,0 +1,112 @@
+/** @file
+ *
+ *  Game State abstract class. Each 'screen' in the game (such as the main menu, the inventory menu
+ *  etc) can be modelled as a 'game state'. Each state has control over it's own drawing and updating.
+ *  This way, we can seperate each portion of the game into its' own little module.
+ *
+ *  <i>ALL</i> game states states must inherit from this class.
+ *
+ *  @copyright 2016-2019  Palm Studios
+ *
+ *  @date 10-2-2019
+ *
+ *  @author Jesse Buhagiar [quaker762]
+ */
+
+#ifndef _GAMESTATE_HPP_
+#define _GAMESTATE_HPP_
+
+#include "SH3/engine/statemanager.hpp"
+
+#include <string>
+#include <memory>
+
+namespace sh3 { namespace state {
+
+class CStateManager; // Forward declaration to prevent circular inclusion
+
+/**
+ * Game state base class. This class is pure virtual.
+ */
+class CGameState
+{
+public:
+
+    /**
+     * Default Constructor
+     *
+     * @warning This constructor is deleted
+     */
+    CGameState() = delete;
+
+    /**
+     * Class constructor
+     *
+     * Passes reference of the game state manager to this state. If this is not the case,
+     * it is <i>impossible</i> for this state to transition to another!
+     */
+    CGameState(CStateManager& mgr)
+    : name(""), id(0), stateManager(mgr)
+    {
+
+    }
+
+    /**
+     *  Virtual Destructor
+     */
+    virtual ~CGameState(){}
+
+    /**
+     * State intiailisation function. When the state manager makes a call to
+     * "changeState", the previous states 'destroy' function is called (unless
+     * we specify that it should NOT be destroyed) and the init function is run.
+     *
+     *
+     */
+    virtual void Init(void) noexcept = 0;
+
+    /**
+     *  Cleanup
+     *
+     *  Most of this could be in the dtor, however it makes more sense for us to have full
+     *  control of when we want cleanup to occur.
+     */
+    virtual void Destroy(void) noexcept = 0;
+
+    /**
+     * State update function.
+     *
+     * The 'heartbeat' of this game state
+     */
+    virtual void Update(void) noexcept = 0;
+
+    /**
+     * State render function.
+     *
+     * All rendering (OpenGL) stuff is to be put in this function
+     */
+    virtual void Render(void) noexcept = 0;
+
+    /**
+     * Input handler function.
+     *
+     * All input is handled/passed here (@z33ky should have a better idea of how this works)
+     */
+    virtual void InputHandler(void) noexcept = 0;
+
+    virtual std::unique_ptr<CGameState> clone() const = 0;
+
+protected:
+    std::string     name;               /**< The name of this state */
+    std::uint64_t   id;                 /**< Numerical ID for this state */
+    CStateManager&  stateManager;       /**< Reference to @ref sh3::engine::CEngine::stateManager */
+};
+
+}}
+
+
+
+
+
+
+#endif /* INCLUDE_SH3_ENGINE_GAMESTATE_HPP_ */

--- a/include/SH3/engine/statemanager.hpp
+++ b/include/SH3/engine/statemanager.hpp
@@ -1,0 +1,71 @@
+/** @file
+ *
+ *  Game state manager. Handles all requests to change, add and remove states from
+ *  the current state list.
+ *
+ *  @copyright 2016-2019  Palm Studios
+ *
+ *  @date 10-2-2019
+ *
+ *  @author Jesse Buhagiar [quaker762]
+ */
+
+#ifndef _STATEMANAGER_HPP_
+#define _STATEMANAGER_HPP_
+
+#include "SH3/engine/gamestate.hpp"
+#include "SH3/common/singleton.hpp"
+
+#include <stack>
+#include <memory>
+
+namespace sh3 { namespace state {
+
+/**
+ *  State manager class. Provides us a way to manage states properly as well as providing an API
+ *  to transition states (and have fancy effects).
+ */
+class CStateManager
+{
+public:
+    /**
+     *
+     */
+    CStateManager();
+
+    /**
+     *  dtor
+     *
+     *  'Unwinds' the stack
+     */
+    ~CStateManager();
+
+    /**
+     * Push a new state to the top of the stack and call @ref sh3::state::CGameState::Init()
+     *
+     * @param
+     */
+    void PushState(const CGameState& state);
+
+    /**
+     * Pop the top of the state stack and call @ref sh3::state::CGameState::Destroy()
+     */
+    void PopState(void);
+
+    /**
+     * Peek the top of the state stack
+     *
+     * @return Gamestate at the top of the stack, @ref stateStack
+     */
+    const std::unique_ptr<CGameState>& Peek(void) const;
+
+private:
+    std::stack<std::unique_ptr<CGameState>>     stateStack;  /**< State list. This could probably an std::vector too */
+    std::uint64_t                               numStates;  /**< Number of states currently on the stack */
+};
+
+}}
+
+
+
+#endif /* INCLUDE_SH3_ENGINE_STATEMANAGER_HPP_ */

--- a/source/SH3/engine/statemanager.cpp
+++ b/source/SH3/engine/statemanager.cpp
@@ -1,0 +1,102 @@
+/** @file
+ *
+ *  Implementation of statemanager.cpp
+ *
+ *  @copyright 2016-2019  Palm Studios
+ *
+ *  @date 10-2-2019
+ *
+ *  @author Jesse Buhagiar [quaker762]
+ */
+#include "SH3/engine/statemanager.hpp"
+#include "SH3/system/log.hpp"
+
+#include <iostream>
+
+using namespace sh3::state;
+
+class StackProtector : public CGameState
+{
+public:
+
+    StackProtector(CStateManager& mgr) : CGameState(mgr)
+    {
+        name = "GUARD_STATE";
+        id = 0;
+    }
+
+
+    /**
+     *
+     */
+    ~StackProtector()
+    {
+    }
+
+    virtual std::unique_ptr<CGameState> clone() const override
+    {
+        return std::make_unique<StackProtector>(*this);
+    }
+
+    virtual void Init(void) noexcept
+    {
+        // Do nothing
+    }
+
+    virtual void Destroy(void) noexcept
+    {
+        die("BLERGH! Call to StackProtector::Destroy (you've tried to underflow the stack!!)");
+    }
+
+    virtual void Update(void) noexcept
+    {
+        std::cout << "TICK ";
+    }
+
+    virtual void Render(void) noexcept
+    {
+        std::cout << "TOCK" << std::endl;
+    }
+
+    virtual void InputHandler(void) noexcept
+    {
+        // Do nothing
+    }
+};
+
+CStateManager::CStateManager(void)
+    : stateStack(), numStates(0)
+{
+    StackProtector protect(*this);
+
+    PushState(protect);
+}
+
+CStateManager::~CStateManager(void)
+{
+    // Unwind the stack
+    for(std::size_t i = 0; i < stateStack.size(); i++)
+    {
+        stateStack.top().get()->Destroy();
+        stateStack.pop();
+    }
+}
+
+void CStateManager::PushState(const CGameState& state)
+{
+    numStates++;
+    stateStack.push(state.clone());
+    stateStack.top().get()->Init();
+}
+
+void CStateManager::PopState(void)
+{
+    numStates--;
+    stateStack.top().get()->Destroy();
+    stateStack.pop();
+}
+
+const std::unique_ptr<CGameState>& CStateManager::Peek(void) const
+{
+    return stateStack.top();
+}


### PR DESCRIPTION
A very barebones implementation of a state based game system. The game
itself is modelled as a series of 'states', a state being an object that
contains all code and data required for a particular 'screen' the game
is in (for example, all 3D geometry data would be loaded in the 'game'
scene, while all inventory data would be contained in the 'inventory'
screen).

As everything in the original SH3 is hardcoded, this
_significantly_ reduces the amount of code required, being that we can
just  feed a scene name (e.g `mr3f) into the state and have it worry
about loading everything.

There is a lot that could be refactored here, as the code is a little
bit janky, but for now this works.