### PR TITLE
Modernised Window class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Makefile
 
 # Documentation
 /docs
+/Debug/

--- a/include/SH3/system/glcontext.hpp
+++ b/include/SH3/system/glcontext.hpp
@@ -19,72 +19,63 @@
 
 #include "SH3/system/sdl_destroyer.hpp"
 
-class sh3_window;
+namespace sh3 { namespace system {
 
-namespace sh3_gl
+class CWindow;  /**< Forward declaration to prevent circular inclusion */
+
+/**
+ * Our OpenGL render context.
+ */
+class CRenderContext
 {
-    class context
-    {
-    public:
-        explicit context(sh3_window& hwnd);
+public:
+    explicit CRenderContext(CWindow& hwnd);
 
-       /**
-        *  Return the vendor of OpenGL Driver in use.
-        */
-        const char* GetVendor() const;
+   /**
+    *  Return the vendor of OpenGL Driver in use.
+    */
+    const char* GetVendor() const;
 
-       /**
-        *  Get the version string of the OpenGL context currently in use.
-        *
-        *  @return OpenGL Version String.
-        */
-        const char* GetVersion() const;
+   /**
+    *  Get the version string of the OpenGL context currently in use.
+    *
+    *  @return OpenGL Version String.
+    */
+    const char* GetVersion() const;
 
-       /**
-        *  Get the name of the renderer (Graphics Card that created this context).
-        *
-        *  @return OpenGL Renderer name (Graphics Card name).
-        */
-        const char* GetRenderer() const;
+   /**
+    *  Get the name of the renderer (Graphics Card that created this context).
+    *
+    *  @return OpenGL Renderer name (Graphics Card name).
+    */
+    const char* GetRenderer() const;
 
-       /**
-        *  Get a list of all extensions supported by the user's graphics card.
-        */
-        void GetExtensions();
+   /**
+    *  Get a list of all extensions supported by the user's graphics card.
+    */
+    void GetExtensions();
 
-       /**
-        *  Print out information about the current GL Context.
-        */
-        void PrintInfo() const;
+   /**
+    *  Print out information about the current GL Context.
+    */
+    void PrintInfo() const;
 
-       /**
-        *   Calculate our projection matrix (how we project vertices on the Z plane on the 2D screen).
-        *   Note that OpenGL has +Z coming TOWARDS the user, which is slightly unintuitive, as it means
-        *   each vertex must have its' Z value inverted.
-        *
-        *   @param fov - The Field Of View (FOV) of our Viewing Frustum. Defined in @ref sh3_graphics::camera.
-        *   @param near - The near plane of our Viewing Frustum, i.e, when objects will disappear.
-        *   @param far - The far plane of our Viewing Frustum, i.e, when far objects will disappear (SH fog etc).
-        *
-        *   @return glm::mat4 - 4 float matrix we send to our GLSL program.
-        */
-        glm::mat4 GetProjectionMatrix(float fov, int width, int height, float near, float far);
+private:
 
-    private:
+   /**
+    *  Get a string from the current GL Context.
+    *
+    *  @param name - Name of symbolic constant we want to get from the driver.
+    *
+    *  @return char* from @c glGetString.
+    */
+    static const char* GlGetString(GLenum name);
 
-       /**
-        *  Get a string from the current GL Context.
-        *
-        *  @param name - Name of symbolic constant we want to get from the driver.
-        *
-        *  @return char* from @c glGetString.
-        */
-        static const char* GlGetString(GLenum name);
+private:
+    std::unique_ptr<flat_sdl_glcontext, sdl_destroyer> glContext;   /**< A pointer to our actual OpenGL Context */
+    std::vector<const char*> extensions;                            /**< List of all extensions supported by this OpenGL Driver */
+};
 
-    private:
-        std::unique_ptr<flat_sdl_glcontext, sdl_destroyer> glContext;   /**< A pointer to our actual OpenGL Context */
-        std::vector<const char*> extensions;                            /**< List of all extensions supported by this OpenGL Driver */
-    };
-}
+}}
 
 #endif // SH3_GLCONTEXT_HPP_INCLUDED

--- a/include/SH3/system/window.hpp
+++ b/include/SH3/system/window.hpp
@@ -5,6 +5,11 @@
  *
  *  @date 22-12-2016
  *
+ *  Revision History:
+ *      24-3-2019:
+ *          + Complete class rewrite.
+ *          + Move class into correct namespace (remove of sh3_ "C style" namespace)
+ *
  *  @author Jesse Buhagiar
  */
 #ifndef SH3_WINDOW_HPP_INCLUDED
@@ -15,21 +20,64 @@
 #include <SDL_video.h>
 #include "SH3/system/glcontext.hpp"
 
+namespace sh3 { namespace system {
+
 /**
  *  Describes a logical Window to interface with SDL2
  */
-class sh3_window
+class CWindow
 {
-private:
+public:
+    static constexpr int SCREEN_WIDTH_DEFAULT   = 1280;     /**< Default screen width(for graphical "safe mode") */
+    static constexpr int SCREEN_HEIGHT_DEFAULT  = 1024;     /**< Default screen height (for graphical "safe mode") */
 
 public:
-    sh3_window(int width, int height, const std::string& title);
+    /**
+     * Class constructor
+     *
+     * @param width     Window width
+     * @param height    Window height
+     * @param title     Window title (for windowed mode)
+     */
+    CWindow(int width, int height, const std::string& title);
 
-    std::unique_ptr<SDL_Window, sdl_destroyer> hwnd;        /**< Our window handle */
-    sh3_gl::context context;                                /**< This window's OpenGL Context */
+    /**
+     * Get the handle to the physical SDL2 window pointer
+     *
+     * @return Returns a <i>physical</i> pointer to @ref hwnd, the non-smart version of the
+     * the SDL2 window.
+     */
+    const SDL_Window* GetHandle(void) const noexcept;
+
+    /**
+     *  Set the size of the window
+     *
+     *  width   The width we want to set the window to
+     *  height  The height we want to set the window to
+     */
+    void SetSize(int width, int height);
+
+    /**
+     * Destroy this window
+     */
+    void Destroy(void);
+
+    /**
+     * Query whether or not this window is fullscreen.
+     *
+     * @return The value of @ref fullscreen
+     */
+    bool IsFullScreen(void) const {return fullscreen;}
 
 private:
+    bool                                        fullscreen;     /**< Is this window currently fullscreen? */
+    std::string                                 title;          /**< Window title (for windowed mode) */
 
+    std::unique_ptr<SDL_Window, sdl_destroyer>  hwnd;           /**< Our window handle */
+    sh3::system::CRenderContext                 context;        /**< This window's OpenGL Context */
+    std::vector<SDL_DisplayMode*>               displayModes;   /**< Display modes list */
 };
+
+}}
 
 #endif // SH3_WINDOW_HPP_INCLUDED

--- a/source/SH3/system/glcontext.cpp
+++ b/source/SH3/system/glcontext.cpp
@@ -122,19 +122,23 @@ static void GLAPIENTRY debugCallback(GLenum source, GLenum type, GLuint id, GLen
     Log(level, errMsg.c_str());
 }
 
-using namespace sh3_gl;
+using namespace sh3::system;
 
-context::context(sh3_window& hwnd)
+CRenderContext::CRenderContext(CWindow& hwnd)
 {
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG); // Put the context into 'forwrad compatible' mode, meaning no deprecated functionality will be allowed AT ALL!
 
-    glContext.reset(SDL_GL_CreateContext(hwnd.hwnd.get()));
+    glContext.reset(SDL_GL_CreateContext(const_cast<SDL_Window*>(hwnd.GetHandle())));
 
-    if(glewInit() != GLEW_OK) // Initialise GLEW!
+    int ret = 0;
+    if((ret = glewInit()) != GLEW_OK) // Initialise GLEW!
     {
-        die("sh3_glcontext::sh3_glcontext( ): GLEW Init failed! (Does your Graphics Driver support OpenGL 3.3?)");
+        std::string err = "CRenderContext::CRenderContext( ): GLEW Init failed! Reason: ";
+        err += std::string(reinterpret_cast<const char*>(glewGetErrorString(ret)));
+
+        die(err.c_str());
     }
 
     // Set the colour size for OpenGL!
@@ -160,22 +164,22 @@ context::context(sh3_window& hwnd)
     }
 }   
 
-const char* context::GetVendor() const
+const char* CRenderContext::GetVendor() const
 {
     return GlGetString(GL_VENDOR);
 }
 
-const char* context::GetVersion() const
+const char* CRenderContext::GetVersion() const
 {
     return GlGetString(GL_VERSION);
 }
 
-const char* context::GetRenderer() const
+const char* CRenderContext::GetRenderer() const
 {
     return GlGetString(GL_RENDERER);
 }
 
-void context::GetExtensions()
+void CRenderContext::GetExtensions()
 {
     GLint numExts;
 
@@ -192,7 +196,7 @@ void context::GetExtensions()
     }
 }
 
-void context::PrintInfo() const
+void CRenderContext::PrintInfo() const
 {
     Log(LogLevel::INFO, "GL_VENDOR:\t %s", GetVendor());
     Log(LogLevel::INFO, "GL_VERSION:\t %s", GetVersion());
@@ -203,12 +207,14 @@ void context::PrintInfo() const
     std::printf("GL_RENDERER:\t %s\n", GetRenderer());
 }
 
-const char* context::GlGetString(GLenum name)
+const char* CRenderContext::GlGetString(GLenum name)
 {
     return reinterpret_cast<const char*>(glGetString(name));
 }
 
-glm::mat4 context::GetProjectionMatrix(float fov, int width, int height, float near, float far)
+/**
+glm::mat4 CRenderContext::GetProjectionMatrix(float fov, int width, int height, float near, float far)
 {
     return glm::perspective(fov, static_cast<float>(width) / static_cast<float>(height), near, far);
 }
+**/

--- a/source/SH3/system/window.cpp
+++ b/source/SH3/system/window.cpp
@@ -22,10 +22,67 @@ Revision History:
 --*/
 #include "SH3/system/glcontext.hpp"
 #include "SH3/system/window.hpp"
+#include "SH3/system/log.hpp"
 
-sh3_window::sh3_window(int width, int height, const std::string& title)
-    : hwnd(SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_UNDEFINED,SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL))
-    , context(*this)
+using namespace sh3::system;
+
+CWindow::CWindow(int width, int height, const std::string& title)
+    : fullscreen(false), title(title), hwnd(SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL)), context(*this)
 {
-    context.PrintInfo();
+    // Populate display mode list
+    SDL_DisplayMode curr;
+    for(int i = 0; i < SDL_GetNumVideoDisplays(); ++i)
+    {
+        int ret = SDL_GetCurrentDisplayMode(i, &curr);
+        if(ret != 0)
+        {
+            std::string err = "Could not get display mode for video display index ";
+            err += i;
+            err +=  "! ";
+            err += SDL_GetError();
+
+            die(err.c_str());
+        }
+
+        displayModes.push_back(&curr);   // Add the current display mode to the list of display modes
+    }
+}
+
+void CWindow::SetSize(int width, int height)
+{
+    Destroy();
+
+    hwnd.reset(SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL));
+    context = CRenderContext(*this);
+
+//    // Do a check to see if we're in fullscreen. If we are
+//    // we'll use one of the video modes we've pre-scanned for!
+//    if(!fullscreen)
+//    {
+//        SDL_SetWindowSize(hwnd.get(), width, height);
+//    }
+//    else
+//    {
+//        // TODO: Search the list of display modes for the correct one!
+//        for(SDL_DisplayMode* mode : displayModes)
+//        {
+//            if(mode->w == width && mode->h == height)
+//            {
+//                SDL_SetWindowDisplayMode(hwnd.get(), mode);
+//                break;
+//            }
+//        }
+//    }
+//
+//    context = CRenderContext(*this); // Refresh the render context
+}
+
+void CWindow::Destroy(void)
+{
+    hwnd.reset();
+}
+
+const SDL_Window* CWindow::GetHandle(void) const noexcept
+{
+    return hwnd.get();
 }

--- a/tests/tex.cpp
+++ b/tests/tex.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     Log(LogLevel::INFO, "===SILENT HILL 3 REDUX===");
     Log(LogLevel::INFO, "Copyright 2016-2017 Palm Studios\n");
 
-    sh3_window window(1024, 768, "sh3redux | texture test");
+    sh3::system::CWindow window(1024, 768, "sh3redux | texture test");
     bool quit = false;
     SDL_Event ev;
     sh3::gl::CShader prog("image");
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
         tex.Bind(GL_TEXTURE1);
         quadVao2.Bind();
         glDrawArrays(GL_TRIANGLES, 0, 6);
-        SDL_GL_SwapWindow(window.hwnd.get());
+        SDL_GL_SwapWindow(const_cast<SDL_Window*>(window.GetHandle()));
     }
 
     return static_cast<int>(exit_code::SUCCESS);


### PR DESCRIPTION
Window class has been thoroughly modernised and moved to the correct namespace (`sh3::system`). More functionality has been added besides just being a Window. The OpenGL contxet class has also been modified to be version 4.0 instead of 3.3.