### PR TITLE
Updated configuration file loader

### DIFF
--- a/include/SH3/engine/engine.hpp
+++ b/include/SH3/engine/engine.hpp
@@ -67,12 +67,12 @@ private:
     void Run(void) noexcept;
 
 private:
-    sh3_config                  config;         /**< The engine's configuration file */
-    bool                        running;        /**< Is the game currently running? */
-    sh3::system::clock_t        clock;          /**< Game clock (for loop timing)*/
-    sh3::state::CStateManager   stateManager;
-    sh3::system::CWindow        hwnd;
-    SDL_Event                   event;
+    sh3::system::CConfigurationFile config;         /**< The engine's configuration file */
+    bool                            running;        /**< Is the game currently running? */
+    sh3::system::clock_t            clock;          /**< Game clock (for loop timing)*/
+    sh3::state::CStateManager       stateManager;
+    sh3::system::CWindow            hwnd;
+    SDL_Event                       event;
 };
 
 }}

--- a/include/SH3/system/config.hpp
+++ b/include/SH3/system/config.hpp
@@ -10,32 +10,78 @@
 #ifndef SH3_CONFIG_H_INCLUDED
 #define SH3_CONFIG_H_INCLUDED
 
-#include <map>
 #include <string>
+#include <unordered_map>
+#include <cstdint>
+#include <fstream>
+
+
+namespace sh3 { namespace system {
 
 /**
- *  Interface for configuration file
+ *  SILENT HILL 3 Configuration File'
+ *
+ *  SILENT HILL 3 does natively come with a configuration file, instead opting to use
+ *  some kind of bizarro binary @c .sys file format. This is a workaround to that, presenting all
+ *  possible options in one single place, @c shr.cfg.
+ *
+ *  The search for a configuration value is sped up by storing them in 'sections', similar to
+ *  an @c .ini file. This way we don't have to search the configuration file (which would
+ *  be at worst case, O(n)) each time during run time to find an option value. The search for
+ *  a configuration section is O(1).
  */
-class sh3_config
+class CConfigurationFile
 {
 public:
+    static constexpr char*  FILENAME            = "sh3r.cfg"; /**< Configuration file name */
+    static constexpr bool   BOOL_DEFAULT_VAL    = false;
+    static constexpr int    INT_DEFAULT_VAL     = 0;
+    static constexpr float  FLOAT_DEFAULT_VAL   = 0.0f;
+
+public:
+    /**
+     * Constructor
+     */
+    CConfigurationFile(){}
 
     /**
-     *  Load the configuration file
-     *
-     *  @return Number of strings read from the file.
+     * Load the file from the disk, and populate the section map
      */
-    int Load();
+    void Load();
 
     /**
-     *  Retrieve a value from an option string
+     * Get a value from the configuration file. The section it resides in MUST
+     * be specified.
      *
-     *  @return Value of option
+     * @tparam T        Type we want to return (interpreted from options)
+     * @param section   Section this option is located in
+     *
+     * @return Option value
+     *
+     * @warning This function <i>could</i> cause a crash if an invalid type if selected. Double check you
+     * have the correct type before using this function.
      */
-    int GetOptionValue(const std::string& option);
+    template <typename T>
+    T GetConfigurationValue(const std::string& section, const std::string& optionName);
 
 private:
-    std::map<std::string, int> values;
+
+    /**
+     * Get byte offset of [section]
+     *
+     * @param sectionName Name of section we want to find
+     *
+     * @returns Byte offset of section on success, -1 on failure
+     */
+    std::int64_t GetSectionOffset(const std::string& sectionName) const;
+
+private:
+    std::ifstream cfgFile;
+    std::unordered_map<std::string, std::uint64_t> sectionMap;
 };
+
+}}
+
+
 
 #endif // SH3_CONFIG_H_INCLUDED

--- a/source/SH3/engine/engine.cpp
+++ b/source/SH3/engine/engine.cpp
@@ -22,7 +22,7 @@ using namespace sh3::engine;
 using namespace std::chrono;
 
 CEngine::CEngine()
-    : config(), running(false), hwnd(640, 480, "SILENT HILL 3: Redux")
+    : running(false), hwnd(640, 480, "SILENT HILL 3: Redux")
 {
 
 }
@@ -42,6 +42,10 @@ void CEngine::Init(const std::string& args)
     sh3::state::CIntroState intro(stateManager);
 
     stateManager.PushState(intro);
+
+    config.Load();
+    bool test = config.GetConfigurationValue<bool>("[test]", "testval");
+    int t2 = config.GetConfigurationValue<float>("[test 2]", "testval");
 
     running = true;
     Run();

--- a/source/SH3/engine/state/intro.cpp
+++ b/source/SH3/engine/state/intro.cpp
@@ -76,6 +76,11 @@ void CIntroState::Destroy(void) noexcept
     glDisable(GL_BLEND); // Disable blending for now
 }
 
+void CIntroState::InputHandler(const SDL_Event& event) noexcept
+{
+
+}
+
 void CIntroState::Update(void) noexcept
 {
     ticks++;
@@ -109,9 +114,4 @@ void CIntroState::Render(void) noexcept
 
     quadVao2.Bind();
     glDrawArrays(GL_TRIANGLES, 0, 6);
-}
-
-void CIntroState::InputHandler(const SDL_Event& event) noexcept
-{
-
 }

--- a/source/SH3/graphics/texture.cpp
+++ b/source/SH3/graphics/texture.cpp
@@ -243,7 +243,7 @@ void CTexture::Load(sh3::arc::mft& mft, const std::string& filename)
                         xoffset ^= 4u;
                     }
 
-                    const auto tempx = x + xoffset; // - 16;
+                    const auto tempx = x + xoffset - 16; // - 16;
                     // every other pixel is for (y + 2)
                     const auto tempy = y + ((i % 2u) ? 2u : 0u);
 

--- a/source/SH3/system/config.cpp
+++ b/source/SH3/system/config.cpp
@@ -1,24 +1,13 @@
-/*++
-
-Copyright (c) 2016  Palm Studios
-
-Module Name:
-        sh3_config.cpp
-
-Abstract:
-        Implementation of sh3_config.hpp
-
-Author:
-        Jesse Buhagiar
-
-Environment:
-
-Notes:
-
-Revision History:
-        27-12-2016: File Created                                                    [jbuhagiar]
-
---*/
+/** @file
+ *
+ *  Implementation of config.hpp
+ *
+ *  @copyright 2016-2019  Palm Studios
+ *
+ *  @date 31-3-2019
+ *
+ *  @author Jesse Buhagiar
+ */
 #include "SH3/system/config.hpp"
 #include "SH3/system/log.hpp"
 
@@ -28,69 +17,153 @@ Revision History:
 #include <utility>
 #include <vector>
 
-/*++
+#include <boost/algorithm/string.hpp>
 
-Routine Description:
-        Load all options and map them to their values in our map
+using namespace sh3::system;
 
-Arguments:
-        None
-
-Return Type:
-        int - Number of Strings read in from the file
-
---*/
-int sh3_config::Load()
+void CConfigurationFile::Load()
 {
-    static const char* CFGPATH = "sh3r.cfg";
+    std::string     line;
+    std::uint64_t   byteIndex = 0;
 
-    std::fstream cfgfile(CFGPATH);
-    if(!cfgfile)
+    cfgFile.open(FILENAME);
+
+    // It seems the file does not exist... Oops!
+    if(!cfgFile.is_open())
     {
-        Log(LogLevel::ERROR, "Unable to find %s! Reverting to default values...", CFGPATH);
-        return -1;
+        Log(LogLevel::ERROR, "Unable to find configuration file! Reverting to default values...");
+        return;
     }
 
-    int         nStrs = 0;
-    std::string command;
-
-    while(getline(cfgfile, command))
+    while(std::getline(cfgFile, line))
     {
-        static const std::string COMMENT = { '#', '$' };
-        if(command.empty() || COMMENT.find(command.front()) != std::string::npos)
+        byteIndex += line.length(); // Get the length of the current line
+        if(line.length() > 0)
         {
-            continue;
+            // This line is a comment
+            if(line.at(0) == '/' && line.at(1) == '/')
+                continue;
+
+            // This line is the start of a configuration section
+            if(line.at(0) == '[' && line.at(line.length() - 1) == ']')
+            {
+                sectionMap.insert(std::make_pair(line, byteIndex)); // Index the beginning of this section. This way we can automatically seek to the correct location
+            }
         }
-
-        // Now, split the command up and store its' value in our map (that we can use later!! :] )
-        const auto commandEnd = find(begin(command), end(command), ' ');
-        std::string key(begin(command), commandEnd),
-                    value(commandEnd, end(command));
-        values[std::move(key)] = std::stoi(std::move(value)); // <- THIS IS VERY DANGEROUS!!!!!!!!
-
-        nStrs++;
     }
 
-    return nStrs;
+    cfgFile.close();
 }
 
-/*++
-
-Routine Description:
-
-
-Arguments:
-
-
-Return Type:
-
-
---*/
-int sh3_config::GetOptionValue(const std::string& option)
+std::int64_t CConfigurationFile::GetSectionOffset(const std::string& sectionName) const
 {
-    auto iter = values.find(option);
-    if(iter == end(values))
-        return -1;
+    std::int64_t            ret = -1;
 
-    return iter->second;
+    auto search = sectionMap.find(sectionName);
+    if(search != sectionMap.end())
+        ret = search->second;
+
+    return ret;
+}
+
+template <>
+bool CConfigurationFile::GetConfigurationValue(const std::string& section, const std::string& option)
+{
+    bool        ret = BOOL_DEFAULT_VAL;
+    int64_t     offset = GetSectionOffset(section);
+    std::string line;
+    std::vector<std::string> split;
+
+    if(offset == -1)
+        return ret;
+
+    cfgFile.open(FILENAME, std::ios_base::openmode::_S_in);
+    cfgFile.seekg(offset, std::ios::beg); // Seek to the section location
+    while(std::getline(cfgFile, line))
+    {
+        /**
+        if(line.size() < 2)
+        {
+            Log(LogLevel::ERROR, "CConfigurationFile::GetConfigurationValue<bool>: line.size() < 2, using default value!);");
+            break;
+        }
+        **/
+
+        boost::split(split, line, boost::algorithm::is_any_of(" "));
+        if(split.at(0) == option)
+        {
+            ret = static_cast<bool>(std::stoi(split.at(1)));
+            break;
+        }
+    }
+
+    return ret;
+}
+
+template <>
+int CConfigurationFile::GetConfigurationValue(const std::string& section, const std::string& option)
+{
+    int         ret = INT_DEFAULT_VAL;
+    int64_t     offset = GetSectionOffset(section);
+    std::string line;
+    std::vector<std::string> split;
+
+    if(offset == -1)
+        return ret;
+
+    cfgFile.open(FILENAME, std::ios_base::openmode::_S_in);
+    cfgFile.seekg(offset, std::ios::beg); // Seek to the section location
+    while(std::getline(cfgFile, line))
+    {
+        /**
+        if(line.size() < 2)
+        {
+            Log(LogLevel::ERROR, "CConfigurationFile::GetConfigurationValue<bool>: line.size() < 2, using default value!);");
+            break;
+        }
+        **/
+
+        boost::split(split, line, boost::algorithm::is_any_of(" "));
+        if(split.at(0) == option)
+        {
+            ret = static_cast<int>(std::stoi(split.at(1)));
+            break;
+        }
+    }
+
+    return ret;
+}
+
+template <>
+float CConfigurationFile::GetConfigurationValue(const std::string& section, const std::string& option)
+{
+    float       ret = FLOAT_DEFAULT_VAL;
+    int64_t     offset = GetSectionOffset(section);
+    std::string line;
+    std::vector<std::string> split;
+
+    if(offset == -1)
+        return ret;
+
+    cfgFile.open(FILENAME, std::ios_base::openmode::_S_in);
+    cfgFile.seekg(offset, std::ios::beg); // Seek to the section location
+    while(std::getline(cfgFile, line))
+    {
+        /**
+        if(line.size() < 2)
+        {
+            Log(LogLevel::ERROR, "CConfigurationFile::GetConfigurationValue<bool>: line.size() < 2, using default value!);");
+            break;
+        }
+        **/
+
+        boost::split(split, line, boost::algorithm::is_any_of(" "));
+        if(split.at(0) == option)
+        {
+            ret = static_cast<float>(std::stof(split.at(1)));
+            break;
+        }
+    }
+
+    return ret;
 }


### PR DESCRIPTION
The configuration file loader has been updated to reflect the new
format. Now, `sh3r.cfg` looks more like a Windows `.ini` file, which
means we are able to map certain settings to their appropriate section.

This commit also contains some engine updates. It's been so long (because of life and Uni) that I
forgot what they were, and I think they're important, so they're being
included in this commit (sorry @z33ky). For anyone following the project
(thanks for all your support!) I have about a month and a bit before
semester starts again, so I'm going to try and get a few things going,
mostly just the main menu. Then it'll be on to getting the 3D formats
all sorted.